### PR TITLE
Don't try to access cont[0] when cont is empty.

### DIFF
--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -542,8 +542,8 @@ public:
         : begin_( cont.data() )
         , end_  ( cont.data() + cont.size() )
 #else
-        : begin_( &cont[0] )
-        , end_  ( &cont[0] + cont.size() )
+        : begin_( cont.size() == 0 ? NULL : &cont[0] )
+        , end_  ( cont.size() == 0 ? NULL : &cont[0] + cont.size() )
 #endif
     {}
 

--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -505,7 +505,7 @@ public:
         Expects( begin <= end );
     }
 
-    gsl_constexpr14 span( pointer & data, size_type size )
+    gsl_constexpr14 span( pointer data, size_type size )
         : begin_( data )
         , end_  ( data + size )
     {


### PR DESCRIPTION
gsl::span constructor should not try to access cont[0] when cont is empty when compiled with C++03.