### PR TITLE
Fix test compilation with GCC 4.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The table below mentions the compiler versions *gsl-lite* is reported to work wi
 OS        | Compiler   | Versions |
 ---------:|:-----------|:---------|
 Windows   | Clang/LLVM | ? |
-&nbsp;    | GCC        | 4.9.2, 5.2.0 |
+&nbsp;    | GCC        | 4.8.4, 4.9.2, 5.2.0 |
 &nbsp;    | Visual C++<br>(Visual Studio)| 6 (6) via header [gsl-lite-vc6.h](include/gsl/gsl-lite-vc6.h)<br>8 (2005), 10 (2010), 11 (2012),<br>12 (2013), 14 (2015) |
 GNU/Linux | Clang/LLVM | 3.4 |
 &nbsp;    | GCC        | 5.1 |

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,35 +16,50 @@ set( SOURCES gsl-lite.t.cpp assert.t.cpp at.t.cpp byte.t.cpp issue.t.cpp not_nul
 add_executable (   gsl-lite.t ${SOURCES} )
 add_definitions( -Dgsl_CONFIG_CONTRACT_VIOLATION_THROWS )
 
-set( SINGLE_TEST_PROGRAM TRUE )
+set( HAS_STD_FLAGS  FALSE )
+set( HAS_CPP11_FLAG FALSE )
+set( HAS_CPP14_FLAG FALSE )
 
-# GNU: have -std=c++14 and lower?
-if( ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" )
-    execute_process(
-        COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-
-    # command line option -std=c++14 since gcc 4.9.2:
-    if( GCC_VERSION VERSION_GREATER 4.9.2 OR GCC_VERSION VERSION_EQUAL 4.9.2 )
-        set( SINGLE_TEST_PROGRAM FALSE )
-    endif()
-endif()
-
-if( ${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC" )
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
     add_compile_options( -W3 -EHsc -D_SCL_SECURE_NO_WARNINGS )
 
-elseif( ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
-        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" )
+elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
+        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
+
+    set( HAS_STD_FLAGS TRUE )
+
+    # GNU: available -std flags depends on version
+    if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" )
+        execute_process(
+            COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+
+        if( GCC_VERSION )
+            if( NOT GCC_VERSION VERSION_LESS 4.8.0 )
+                set( HAS_CPP11_FLAG TRUE )
+            endif()
+            if( NOT GCC_VERSION VERSION_LESS 4.9.2 )
+                set( HAS_CPP14_FLAG TRUE )
+            endif()
+        endif()
+    endif()
+
     add_executable( gsl-lite-cpp98.t ${SOURCES} )
+    target_compile_options( gsl-lite-cpp98.t  PUBLIC -std=c++98 )
+
     add_executable( gsl-lite-cpp03.t ${SOURCES} )
-    add_executable( gsl-lite-cpp11.t ${SOURCES} )
-    add_executable( gsl-lite-cpp14.t ${SOURCES} )
+    target_compile_options( gsl-lite-cpp03.t  PUBLIC -std=c++03 )
+
+    if( HAS_CPP11_FLAG )
+        add_executable( gsl-lite-cpp11.t ${SOURCES} )
+        target_compile_options( gsl-lite-cpp11.t  PUBLIC -std=c++11 )
+    endif()
+
+    if( HAS_CPP14_FLAG )
+        add_executable( gsl-lite-cpp14.t ${SOURCES} )
+        target_compile_options( gsl-lite-cpp14.t  PUBLIC -std=c++14 )
+    endif()
 
     add_compile_options( -Wall -Wno-missing-braces -fno-elide-constructors )
-
-    target_compile_options( gsl-lite-cpp98.t  PUBLIC -std=c++98 )
-    target_compile_options( gsl-lite-cpp03.t  PUBLIC -std=c++03 )
-    target_compile_options( gsl-lite-cpp11.t  PUBLIC -std=c++11 )
-    target_compile_options( gsl-lite-cpp14.t  PUBLIC -std=c++14 )
 
 elseif( ${CMAKE_CXX_COMPILER_ID} MATCHES "Intel" )
 # as is
@@ -56,14 +71,18 @@ endif()
 
 enable_testing()
 
- if( ${SINGLE_TEST_PROGRAM} )
-add_test( NAME test          COMMAND gsl-lite.t --pass )
- else()
-add_test( NAME test-cpp98    COMMAND gsl-lite-cpp98.t )
-add_test( NAME test-cpp03    COMMAND gsl-lite-cpp03.t )
-add_test( NAME test-cpp11    COMMAND gsl-lite-cpp11.t )
-add_test( NAME test-cpp14    COMMAND gsl-lite-cpp14.t --pass )
- endif()
+if( NOT HAS_STD_FLAGS )
+    add_test( NAME test          COMMAND gsl-lite.t --pass )
+else()
+    add_test( NAME test-cpp98    COMMAND gsl-lite-cpp98.t )
+    add_test( NAME test-cpp03    COMMAND gsl-lite-cpp03.t )
+    if( HAS_CPP11_FLAG )
+        add_test( NAME test-cpp11    COMMAND gsl-lite-cpp11.t )
+    endif()
+    if( HAS_CPP14_FLAG )
+        add_test( NAME test-cpp14    COMMAND gsl-lite-cpp14.t --pass )
+    endif()
+endif()
 add_test( NAME list_version  COMMAND gsl-lite.t --version )
 add_test( NAME list_tags     COMMAND gsl-lite.t --list-tags )
 add_test( NAME list_tests    COMMAND gsl-lite.t --list-tests )


### PR DESCRIPTION
gsl-lite works with GCC 4.8.4 (it passes its tests, and works on our project, although we don't make a lot of use of it yet).

However, the CMake code for building the tests required some rearranging.