### PR TITLE
Free-standing functions: as_bytes, as_writable_bytes

### DIFF
--- a/include/gsl/gsl-lite-vc6.h
+++ b/include/gsl/gsl-lite-vc6.h
@@ -564,6 +564,18 @@ private:
 
 // span creator functions (see ctors)
 
+template< typename T>
+span< const byte > as_bytes(span<T> other)
+{
+    return span< const byte >( reinterpret_cast<const byte *>( other.data() ), other.bytes() );
+}
+
+template< typename T>
+span< byte > as_writeable_bytes(span<T> other)
+{
+    return span< byte >( reinterpret_cast<byte *>( other.data() ), other.bytes() );
+}
+
 template< typename T >
 span<T> as_span( T * begin, T * end )
 {

--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -1408,6 +1408,18 @@ void copy( span<T> src, span<U> dest )
 // span creator functions (see ctors)
 
 template< typename T >
+gsl_api span< const byte > as_bytes(span<T> other) gsl_noexcept
+{
+    return span< const byte >( reinterpret_cast<const byte *>( other.data() ), other.bytes() );
+}
+
+template< typename T>
+gsl_api span< byte > as_writeable_bytes(span<T> other) gsl_noexcept
+{
+    return span< byte >( reinterpret_cast<byte *>( other.data() ), other.bytes() );
+}
+
+template< typename T >
 gsl_api gsl_constexpr14 span<T> as_span( T * begin, T * end )
 {
     return span<T>( begin, end );

--- a/test/span.t.cpp
+++ b/test/span.t.cpp
@@ -946,11 +946,16 @@ CASE( "span<>: Allows to view the elements as read-only bytes" )
 
     span<int> va( a );
     span<const gyte> vb( va.as_bytes() );
+    span<const gyte> vc(as_bytes(va));
 
     EXPECT( vb[0] == b[0] );
+    EXPECT( vc[0] == b[0] );
     EXPECT( vb[1] == b[1] );
+    EXPECT( vc[1] == b[1] );
     EXPECT( vb[2] == b[2] );
+    EXPECT( vc[2] == b[2] );
     EXPECT( vb[3] == b[3] );
+    EXPECT( vc[3] == b[3] );
 }
 
 CASE( "span<>: Allows to view and change the elements as writable bytes" )
@@ -967,13 +972,20 @@ CASE( "span<>: Allows to view and change the elements as writable bytes" )
     type  a[] = { 0x0, };
     span<int> va( a );
     span<gyte> vb( va.as_writeable_bytes() );
+    span<gyte> vc( as_writeable_bytes(va) );
 
-    {for ( size_t i = 0; i < sizeof(type); ++i ) EXPECT( vb[i] == to_byte(0) ); }
+    for ( size_t i = 0; i < sizeof(type); ++i ) {
+        EXPECT( vb[i] == to_byte(0) );
+        EXPECT( vc[i] == to_byte(0) );
+    }
 
     vb[0] = to_byte(0x42);
 
     EXPECT( vb[0] == to_byte(0x42) );
-    {for ( size_t i = 1; i < sizeof(type); ++i ) EXPECT( vb[i] == to_byte(0) ); }
+    for ( size_t i = 1; i < sizeof(type); ++i ) {
+        EXPECT( vb[i] == to_byte(0) );
+        EXPECT( vc[i] == to_byte(0) );
+    }
 }
 
 CASE( "span<>: Allows to view the elements as a span of another type" )


### PR DESCRIPTION
Microsoft Guideline Support Library has free-standing variant of as_bytes and as_writable_bytes. I have missed them switching from Microsoft GSL to gsl-lite(because of C++ standard downgrade).