### PR TITLE
Use noexcept with default ctors/dtors for GCC >= 4.9.0

### DIFF
--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -1656,9 +1656,16 @@ public:
     {}
 
 #if gsl_HAVE_IS_DEFAULT
+
+#if gsl_BETWEEN( gsl_COMPILER_GCC_VERSION, 490, 600)
     gsl_api gsl_constexpr basic_string_span( basic_string_span const & rhs ) gsl_noexcept = default;
 
     gsl_api gsl_constexpr basic_string_span( basic_string_span && rhs ) gsl_noexcept = default;
+#else
+    gsl_api gsl_constexpr basic_string_span( basic_string_span const & rhs ) = default;
+
+    gsl_api gsl_constexpr basic_string_span( basic_string_span && rhs ) = default;
+#endif
 #endif
 
     template< class U


### PR DESCRIPTION
https://github.com/martinmoene/gsl-lite/commit/04398888118de3bb2fe512822190e4edda2c0fed breaks compilation on GCC < 4.9.0.

I'm not sure which particular GCC bug corresponds to it:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53903
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53901

or some else.