### PR TITLE
Fix -Wshadow warning

### DIFF
--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -1707,8 +1707,8 @@ public:
     : span_( ptr, count )
     {}
 
-    gsl_api gsl_constexpr basic_string_span( pointer first, pointer last )
-    : span_( first, last )
+    gsl_api gsl_constexpr basic_string_span( pointer firstElem, pointer lastElem )
+    : span_( firstElem, lastElem )
     {}
 
     template< std::size_t N >


### PR DESCRIPTION
With certain compilers (e.g. gcc 4.8.5), compiling with `-Wshadow` triggers a shadow warning on the local variables "first" and "last" in the `basic_string_span` constructor, because the shadow the "first" and "last" member functions, respectively:
```
In file included from test.cpp:1:0:
gsl/gsl-lite.h: In constructor ‘constexpr gsl::basic_string_span<T>::basic_string_span(gsl::basic_string_span<T>::pointer, gsl::basic_string_span<T>::pointer)’:
gsl/gsl-lite.h:1711:5: warning: declaration of ‘last’ shadows a member of 'this' [-Wshadow]
     : span_( first, last )
     ^
gsl/gsl-lite.h:1711:5: warning: declaration of ‘first’ shadows a member of 'this' [-Wshadow]
```
This gets annoying real fast, since it shows up for every source file that ends up including gsl-lite.

This has already been fixed in Microsoft's GSL by naming the variables "firstElem" and "lastElem", respectively. This fix does the same.