### PR TITLE
Changed nullptr to gsl_nullptr in not_nul::get().

### DIFF
--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -885,7 +885,7 @@ public:
 
     gsl_api gsl_constexpr14 T get() const
     {
-        Ensures( ptr_ != nullptr );
+        Ensures( ptr_ != gsl_nullptr );
         return ptr_;
     }
 


### PR DESCRIPTION
The `nullptr` in `not_null::get()` warns about C++11 keywords (`-Wc++11-compat`) on gcc for the cpp03 tests, and fails to compile with strict c++03 compatibility.