### PR TITLE
Silence warnings in MSVC >= 1911 (VS2017)

### DIFF
--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -1142,7 +1142,7 @@ gsl_api inline gsl_constexpr byte operator~( byte b ) gsl_noexcept
 }
 
 // tag to select span constructor taking a container
-struct with_container_t{ gsl_constexpr14 with_container_t(){} };
+struct with_container_t{ gsl_constexpr14 with_container_t() gsl_noexcept {} };
 const with_container_t with_container;
 
 //
@@ -1225,7 +1225,7 @@ public:
     }
 
     template< class U, size_t N >
-    gsl_api gsl_constexpr14 span( U (&arr)[N] )
+    gsl_api gsl_constexpr14 span( U (&arr)[N] ) gsl_noexcept
         : first_( &arr[0] )
         , last_ ( &arr[0] + N )
     {}

--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -733,6 +733,9 @@ gsl_api inline final_action_error on_error( F const & action )
 template< class T, class U >
 gsl_api inline gsl_constexpr T narrow_cast( U && u ) gsl_noexcept
 {
+#ifdef _MSC_VER
+#pragma warning(suppress: 26472)
+#endif
     return static_cast<T>( std::forward<U>( u ) );
 }
 
@@ -1003,6 +1006,9 @@ gsl_api inline gsl_constexpr byte to_byte( T v ) gsl_noexcept
 #if    gsl_HAVE_ENUM_CLASS_CONSTRUCTION_FROM_UNDERLYING_TYPE
     return static_cast<byte>( v );
 #elif  gsl_HAVE_CONSTEXPR_11
+#ifdef _MSC_VER
+#pragma warning(suppress: 26472)
+#endif
     return { static_cast<typename byte::type>( v ) };
 #else
     byte b = { static_cast<typename byte::type>( v ) }; return b;
@@ -1026,6 +1032,9 @@ gsl_api inline gsl_constexpr unsigned char to_uchar( byte b ) gsl_noexcept
 
 gsl_api inline gsl_constexpr unsigned char to_uchar( int i ) gsl_noexcept
 {
+#ifdef _MSC_VER
+#pragma warning(suppress: 26472)
+#endif
     return static_cast<unsigned char>( i );
 }
 

--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -475,7 +475,7 @@ gsl_api inline gsl_constexpr14 void fail_fast_assert( bool cond, char const * co
 
 # else
 
-gsl_api inline gsl_constexpr14 void fail_fast_assert( bool cond )
+gsl_api inline gsl_constexpr14 void fail_fast_assert( bool cond ) gsl_noexcept
 {
     if ( !cond )
         std::terminate();

--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -1230,6 +1230,9 @@ public:
     template< class U, size_t N >
     gsl_api gsl_constexpr14 span( U (&arr)[N] ) gsl_noexcept
         : first_( &arr[0] )
+#ifdef _MSC_VER
+#pragma warning(suppress: 26481)
+#endif
         , last_ ( &arr[0] + N )
     {}
 

--- a/include/gsl/gsl-lite.h
+++ b/include/gsl/gsl-lite.h
@@ -1143,6 +1143,9 @@ gsl_api inline gsl_constexpr byte operator~( byte b ) gsl_noexcept
 
 // tag to select span constructor taking a container
 struct with_container_t{ gsl_constexpr14 with_container_t() gsl_noexcept {} };
+#ifdef _MSC_VER
+#pragma warning(suppress: 26426)
+#endif
 const with_container_t with_container;
 
 //


### PR DESCRIPTION
This is 1 commit na going to be list of possible commits to fix most (if not all) of MSVC's warnings.