### PR TITLE
CMake package configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,20 +5,66 @@
 #
 # This code is licensed under the MIT License (MIT).
 
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project( gsl_lite )
+include(CMakePackageConfigHelpers)
 
-include( GNUInstallDirs )
+set(package_name "gsl-lite")
 
-add_library(    gsl_lite INTERFACE )
-target_sources( gsl_lite INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/gsl-lite.natvis )
+project(${package_name} VERSION 0.29.0 LANGUAGES CXX)
 
+set(include_source_dir "${PROJECT_SOURCE_DIR}/include")
+set(include_install_dir "include")
+set(package_config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(package_config_file "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+set(package_version_file
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  )
+set(package_export_name "${PROJECT_NAME}Targets")
+set(package_namespace "${PROJECT_NAME}::")
+
+# Interface library
+add_library(${package_name} INTERFACE)
+target_include_directories(${package_name}
+  INTERFACE
+    "$<BUILD_INTERFACE:${include_source_dir}>"
+  )
+target_sources(${package_name}
+  INTERFACE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/gsl-lite.natvis>"
+  )
+
+# Package configuration
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/PackageConfig.cmake.in"
+  ${package_config_file}
+  INSTALL_DESTINATION ${package_config_install_dir}
+)
+write_basic_package_version_file(${package_version_file}
+  COMPATIBILITY SameMajorVersion
+)
+
+# Installation
+install(
+  TARGETS ${package_name}
+  EXPORT ${package_export_name}
+  INCLUDES DESTINATION ${include_install_dir}
+  )
+install(
+  EXPORT ${package_export_name}
+  NAMESPACE ${package_namespace}
+  DESTINATION ${package_config_install_dir}
+)
+install(
+  DIRECTORY "${include_source_dir}/"
+  DESTINATION ${include_install_dir}
+  )
+install(
+  FILES
+    "${package_config_file}"
+    "${package_version_file}"
+  DESTINATION ${package_config_install_dir}
+  )
+
+# Test
 enable_testing()
-
-add_subdirectory( test )
-#add_subdirectory( example )
-
-install( DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
-
-# end of file
+add_subdirectory(test)

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@package_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,167 +5,216 @@
 #
 # This code is licensed under the MIT License (MIT).
 
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project( test )
+project(gsl-lite_test)
 
-set( INCDIRS "${PROJECT_SOURCE_DIR}/../include/gsl" )
+set(INCDIRS "${PROJECT_SOURCE_DIR}/../include/gsl")
 
-set( SOURCES gsl-lite.t.cpp assert.t.cpp at.t.cpp byte.t.cpp issue.t.cpp not_null.t.cpp owner.t.cpp span.t.cpp string_span.t.cpp util.t.cpp )
+set(SOURCES
+  gsl-lite.t.cpp
+  assert.t.cpp
+  at.t.cpp
+  byte.t.cpp
+  issue.t.cpp
+  not_null.t.cpp
+  owner.t.cpp
+  span.t.cpp
+  string_span.t.cpp
+  util.t.cpp
+  )
 
-set( GSL_CONFIG -Dgsl_CONFIG_CONTRACT_VIOLATION_THROWS )
+set(GSL_CONFIG -Dgsl_CONFIG_CONTRACT_VIOLATION_THROWS)
 
-set( HAS_STD_FLAGS  FALSE )
-set( HAS_CPP98_FLAG FALSE )
-set( HAS_CPP03_FLAG FALSE )
-set( HAS_CPP11_FLAG FALSE )
-set( HAS_CPP14_FLAG FALSE )
-set( HAS_CPP17_FLAG FALSE )
-set( HAS_CPP20_FLAG FALSE )
+set(HAS_STD_FLAGS FALSE)
+set(HAS_CPP98_FLAG FALSE)
+set(HAS_CPP03_FLAG FALSE)
+set(HAS_CPP11_FLAG FALSE)
+set(HAS_CPP14_FLAG FALSE)
+set(HAS_CPP17_FLAG FALSE)
+set(HAS_CPP20_FLAG FALSE)
 
-if( MSVC )
-    set( HAS_STD_FLAGS TRUE )
+if(MSVC)
+  set(HAS_STD_FLAGS TRUE)
+  set(STD_OPT -std:)
+  set(OPTIONS -W3 -EHsc)
+  set(DEFINITIONS -D_SCL_SECURE_NO_WARNINGS -DNOMINMAX ${GSL_CONFIG})
 
-    set( STD_OPT     -std: )
-    set( OPTIONS     -W3 -EHsc )
-    set( DEFINITIONS -D_SCL_SECURE_NO_WARNINGS -DNOMINMAX ${GSL_CONFIG} )
+  if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.00)
+    set(HAS_CPP14_FLAG TRUE)
+    set(HAS_CPPLATEST_FLAG TRUE)
+  endif()
 
-    if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.00 )
-        set( HAS_CPP14_FLAG TRUE )
-        set( HAS_CPPLATEST_FLAG TRUE )
-    endif()
-    if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.11 )
-        set( HAS_CPP17_FLAG TRUE )
-    endif()
+  if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.11)
+    set(HAS_CPP17_FLAG TRUE)
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+       OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(HAS_STD_FLAGS TRUE)
+  set(HAS_CPP98_FLAG TRUE)
+  set(HAS_CPP03_FLAG TRUE)
+  set(STD_OPT -std=)
+  set(OPTIONS
+    -Wall
+    -Wno-missing-braces
+    -fno-elide-constructors
+    -Wconversion
+    -Wsign-conversion
+    -Wno-string-conversion
+    ${GSL_CONFIG}
+    )
+  set(DEFINITIONS "")
 
-elseif( CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
-        CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-
-    set( HAS_STD_FLAGS  TRUE )
-    set( HAS_CPP98_FLAG TRUE )
-    set( HAS_CPP03_FLAG TRUE )
-
-    set( STD_OPT     -std= )
-    set( OPTIONS     -Wall -Wno-missing-braces -fno-elide-constructors -Wconversion -Wsign-conversion -Wno-string-conversion ${GSL_CONFIG} )
-    set( DEFINITIONS "" )
-
-    # GNU: available -std flags depends on version
-    if( CMAKE_CXX_COMPILER_ID MATCHES "GNU" )
-        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8.0 )
-            set( HAS_CPP11_FLAG TRUE )
-        endif()
-        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.2 )
-            set( HAS_CPP14_FLAG TRUE )
-        endif()
-        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.1.0 )
-            set( HAS_CPP17_FLAG TRUE )
-        endif()
-    endif()
-
-    # Clang: available -std flags depends on version
-    if( CMAKE_CXX_COMPILER_ID MATCHES Clang )
-        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3.0 )
-            set( HAS_CPP11_FLAG TRUE )
-        endif()
-        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4.0 )
-            set( HAS_CPP14_FLAG TRUE )
-        endif()
-        if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0.0 )
-            set( HAS_CPP17_FLAG TRUE )
-        endif()
+  # GNU: available -std flags depends on version
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8.0)
+      set(HAS_CPP11_FLAG TRUE)
     endif()
 
-elseif( CMAKE_CXX_COMPILER_ID MATCHES "Intel" )
-# as is
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.2)
+      set(HAS_CPP14_FLAG TRUE)
+    endif()
+
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.1.0)
+      set(HAS_CPP17_FLAG TRUE)
+    endif()
+  endif()
+
+  # Clang: available -std flags depends on version
+  if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3.0)
+      set(HAS_CPP11_FLAG TRUE)
+    endif()
+
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4.0)
+      set(HAS_CPP14_FLAG TRUE)
+    endif()
+
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0.0)
+        set(HAS_CPP17_FLAG TRUE)
+    endif()
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+  # as is
 else()
-# as is
+  # as is
 endif()
 
 # enable MS C++ Core Guidelines checker if MSVC:
-
-function( enable_msvs_guideline_checker target )
-    if( MSVC )
-        set_target_properties( ${target} PROPERTIES
+# TODO(2018-02-18 by wolters) Move all MSVS CppCoreCheck functionality into a
+# separate CMake module.
+function(msvc_cpp_core_guidelines_checker_enable target)
+  if(MSVC
+     AND MSVC_VERSION GREATER_EQUAL 1910
+    )
+    set_target_properties(${target}
+      PROPERTIES
         VS_GLOBAL_EnableCppCoreCheck true
         VS_GLOBAL_CodeAnalysisRuleSet CppCoreCheckRules.ruleset
-        VS_GLOBAL_RunCodeAnalysis true )
-    endif()
+        VS_GLOBAL_RunCodeAnalysis true
+     )
+  endif()
 endfunction()
 
 # make target, compile for given standard if specified:
 
-function( make_target target std )
-    if( std )
-        set( OPTIONAL_STD ${STD_OPT}${std} )
-    endif()
-    add_executable            ( ${target} ${SOURCES}  )
-    target_compile_options    ( ${target} PRIVATE ${OPTIONS} ${OPTIONAL_STD} )
-    target_compile_definitions( ${target} PRIVATE ${DEFINITIONS} )
-    target_include_directories( ${target} PRIVATE ${INCDIRS} )
+function(make_target target std)
+  if(std)
+    set(OPTIONAL_STD ${STD_OPT}${std})
+  endif()
+
+  add_executable(${target} ${SOURCES})
+  target_compile_options(${target} PRIVATE ${OPTIONS} ${OPTIONAL_STD})
+  target_compile_definitions(${target} PRIVATE ${DEFINITIONS})
+  target_include_directories(${target} PRIVATE ${INCDIRS})
 endfunction()
 
 # add generic executable, unless -std flags can be specified:
 
-if( NOT HAS_STD_FLAGS )
-    make_target( gsl-lite.t "" )
+if(NOT HAS_STD_FLAGS)
+  make_target(gsl-lite.t "")
 else()
-    # unconditionally add C++98 variant as MSVC has no option for it:
-    if( HAS_CPP98_FLAG )
-        make_target( gsl-lite-cpp98.t c++98 )
-    else()
-        make_target( gsl-lite-cpp98.t "" )
-    endif()
+  find_path(CppCoreCheck_INCLUDE_DIR
+    NAMES "CppCoreCheck/warnings.h"
+    PATHS
+      "$ENV{VS2017INSTALLDIR}/VC/Auxiliary/VS/include"
+    )
+  set(CppCoreCheck_INCLUDE_DIRS "${CppCoreCheck_INCLUDE_DIR}")
 
-    if( HAS_CPP03_FLAG )
-        make_target( gsl-lite-cpp03.t c++03 )
-    endif()
+  # unconditionally add C++98 variant as MSVC has no option for it:
+  if(HAS_CPP98_FLAG)
+    make_target(gsl-lite-cpp98.t c++98)
+  else()
+    make_target(gsl-lite-cpp98.t "")
+  endif()
 
-    if( HAS_CPP11_FLAG )
-        make_target( gsl-lite-cpp11.t c++11 )
-    endif()
+  target_include_directories(gsl-lite-cpp98.t
+    PRIVATE ${CppCoreCheck_INCLUDE_DIRS}
+    )
 
-    if( HAS_CPP14_FLAG )
-        make_target( gsl-lite-cpp14.t c++14 )
-    endif()
+  if(HAS_CPP03_FLAG)
+    make_target(gsl-lite-cpp03.t c++03)
+    target_include_directories(gsl-lite-cpp03.t
+      PRIVATE ${CppCoreCheck_INCLUDE_DIRS}
+      )
+  endif()
 
-    if( HAS_CPP17_FLAG )
-        make_target( gsl-lite-cpp17.t c++17 )
-        enable_msvs_guideline_checker( gsl-lite-cpp17.t )
-    endif()
+  if(HAS_CPP11_FLAG)
+    make_target(gsl-lite-cpp11.t c++11)
+    target_include_directories(gsl-lite-cpp11.t
+      PRIVATE ${CppCoreCheck_INCLUDE_DIRS}
+      )
+  endif()
 
-    if( HAS_CPPLATEST_FLAG )
-        make_target( gsl-lite-cpplatest.t c++latest )
-    endif()
+  if(HAS_CPP14_FLAG)
+    make_target(gsl-lite-cpp14.t c++14)
+    target_include_directories(gsl-lite-cpp14.t
+      PRIVATE ${CppCoreCheck_INCLUDE_DIRS}
+      )
+  endif()
+
+  if(HAS_CPP17_FLAG)
+    make_target(gsl-lite-cpp17.t c++17)
+    target_include_directories(gsl-lite-cpp17.t
+      PRIVATE ${CppCoreCheck_INCLUDE_DIRS}
+      )
+    msvc_cpp_core_guidelines_checker_enable(gsl-lite-cpp17.t)
+  endif()
+
+  if(HAS_CPPLATEST_FLAG)
+    make_target(gsl-lite-cpplatest.t c++latest)
+    target_include_directories(gsl-lite-cpplatest.t
+      PRIVATE ${CppCoreCheck_INCLUDE_DIRS}
+      )
+  endif()
 endif()
 
-# configure unit tests via CTest:
+if(HAS_STD_FLAGS)
+  # unconditionally add C++98 variant for MSVC:
+  add_test(NAME test-cpp98 COMMAND gsl-lite-cpp98.t)
 
-enable_testing()
+  if(HAS_CPP03_FLAG)
+    add_test(NAME test-cpp03 COMMAND gsl-lite-cpp03.t)
+  endif()
 
-if( HAS_STD_FLAGS )
-    # unconditionally add C++98 variant for MSVC:
-    add_test(     NAME test-cpp98     COMMAND gsl-lite-cpp98.t )
+  if(HAS_CPP11_FLAG)
+    add_test(NAME test-cpp11 COMMAND gsl-lite-cpp11.t)
+  endif()
 
-    if( HAS_CPP03_FLAG )
-        add_test( NAME test-cpp03     COMMAND gsl-lite-cpp03.t )
-    endif()
-    if( HAS_CPP11_FLAG )
-        add_test( NAME test-cpp11     COMMAND gsl-lite-cpp11.t )
-    endif()
-    if( HAS_CPP14_FLAG )
-        add_test( NAME test-cpp14     COMMAND gsl-lite-cpp14.t )
-    endif()
-    if( HAS_CPP17_FLAG )
-        add_test( NAME test-cpp17     COMMAND gsl-lite-cpp17.t )
-    endif()
-    if( HAS_CPPLATEST_FLAG )
-        add_test( NAME test-cpplatest COMMAND gsl-lite-cpplatest.t )
-    endif()
+  if(HAS_CPP14_FLAG)
+    add_test(NAME test-cpp14 COMMAND gsl-lite-cpp14.t)
+  endif()
+
+  if(HAS_CPP17_FLAG)
+    add_test(NAME test-cpp17 COMMAND gsl-lite-cpp17.t)
+  endif()
+
+  if(HAS_CPPLATEST_FLAG)
+    add_test(NAME test-cpplatest COMMAND gsl-lite-cpplatest.t)
+  endif()
 else()
-    add_test(     NAME test           COMMAND gsl-lite.t --pass )
-    add_test(     NAME list_version   COMMAND gsl-lite.t --version )
-    add_test(     NAME list_tags      COMMAND gsl-lite.t --list-tags )
-    add_test(     NAME list_tests     COMMAND gsl-lite.t --list-tests )
+  add_test(NAME test COMMAND gsl-lite.t --pass)
+  add_test(NAME list_version COMMAND gsl-lite.t --version)
+  add_test(NAME list_tags COMMAND gsl-lite.t --list-tags)
+  add_test(NAME list_tests COMMAND gsl-lite.t --list-tests)
 endif()
-
-# end of file

--- a/test/gsl-lite.t.hpp
+++ b/test/gsl-lite.t.hpp
@@ -22,7 +22,7 @@
 // Limit C++ Core Guidelines checking to GSL Lite:
 
 #if defined(_MSC_VER) && _MSC_VER >= 1910
-# include <CppCoreCheck/Warnings.h>
+# include <CppCoreCheck/warnings.h>
 # pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
 #endif
 


### PR DESCRIPTION
I've added [CMake Package](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html) support for gsl-lite, which makes it easy to install and consume gsl-lite as a package with the build system CMake.

### Installation

Hint: I am using MSVS 2017 and Ninja

    cmake -H. -B../_build -G"Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=cl -DCMAKE_INSTALL_PREFIX="D:/dev/native/gsl-lite/gsl-lite-0.29.0"
    cmake --build ../_build --config Release --target install

### Consumption

Consider a package `package_using_gsl-lite` that would like to use v0.29.0 of the package `gsl-lite`.

`CMakeLists.txt`:

    cmake_minimum_required(VERSION 3.0 FATAL_ERROR)

    find_package(gsl-lite 0.29 REQUIRED)

    project("package_using_gsl-lite" LANGUAGES CXX)

    add_executable("package_using_gsl-lite" main.cpp)
    target_link_libraries("package_using_gsl-lite"
      PRIVATE gsl-lite::gsl-lite
      )

`main.cpp`:

    // Standard Library
    #include <iostream>
    #include <string>

    // Guideline Support Library (GSL)
    #include <gsl/gsl>

    void not_null_example(const gsl::not_null<const std::string*> arg) {
      // NOOP
    }

    int main() {
      using UniqueImmutableStringPtr = std::unique_ptr<const std::string>;
      const UniqueImmutableStringPtr text = std::make_unique<std::string>("hello, gsl");
      not_null_example(text.get());
      //not_null_example(nullptr);  

      std::cout << text.get() << '\n';
    }

The variable `gsl-lite_DIR` can be used to specify the path to the CMake Package Configuration file of gsl-lite.

    cmake -H. -B../_build -G"Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=cl -DCMAKE_INSTALL_PREFIX=_stage -Dgsl-lite_DIR="D:/dev/native/gsl-lite/gsl-lite-0.29.0/lib/cmake/gsl-lite"
    cmake --build ../_build --config Release

This resolves issue #38, imo. I've implemented it in a modern CMake-idiomatic and simple way.