### PR TITLE
Introduce support for DJGPP cross compiler

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -139,6 +139,14 @@
 # define gsl_COMPILER_GNUC_VERSION  0
 #endif
 
+// Presence of wide character support:
+
+#ifdef __DJGPP__
+# define gsl_HAVE_WCHAR 0
+#else
+# define gsl_HAVE_WCHAR 1
+#endif
+
 // Presence of C++11 language features:
 
 #define gsl_CPP11_10  (gsl_CPP11_OR_GREATER || gsl_COMPILER_MSVC_VERSION >= 10)
@@ -2186,14 +2194,18 @@ gsl_api inline span< const byte > as_bytes( basic_string_span<T> spn ) gsl_noexc
 //
 
 typedef char * zstring;
-typedef wchar_t * zwstring;
 typedef const char * czstring;
+#if gsl_HAVE_WCHAR
+typedef wchar_t * zwstring;
 typedef const wchar_t * cwzstring;
+#endif // gsl_HAVE_WCHAR
 
 typedef basic_string_span< char > string_span;
-typedef basic_string_span< wchar_t > wstring_span;
 typedef basic_string_span< char const > cstring_span;
+#if gsl_HAVE_WCHAR
+typedef basic_string_span< wchar_t > wstring_span;
 typedef basic_string_span< wchar_t const > cwstring_span;
+#endif // gsl_HAVE_WCHAR
 
 // to_string() allow (explicit) conversions from string_span to string
 
@@ -2217,6 +2229,7 @@ gsl_api inline std::string to_string( cstring_span const & spn )
     return std::string( spn.data(), spn.length() );
 }
 
+#if gsl_HAVE_WCHAR
 gsl_api inline std::wstring to_string( wstring_span const & spn )
 {
     return std::wstring( spn.data(), spn.length() );
@@ -2226,6 +2239,7 @@ gsl_api inline std::wstring to_string( cwstring_span const & spn )
 {
     return std::wstring( spn.data(), spn.length() );
 }
+#endif // gsl_HAVE_WCHAR
 
 #endif // to_string()
 
@@ -2285,6 +2299,7 @@ gsl_api std::basic_ostream< char, Traits > & operator<<( std::basic_ostream< cha
     return detail::write_to_stream( os, spn );
 }
 
+#if gsl_HAVE_WCHAR
 template< typename Traits >
 gsl_api std::basic_ostream< wchar_t, Traits > & operator<<( std::basic_ostream< wchar_t, Traits > & os, wstring_span const & spn )
 {
@@ -2296,6 +2311,7 @@ gsl_api std::basic_ostream< wchar_t, Traits > & operator<<( std::basic_ostream< 
 {
     return detail::write_to_stream( os, spn );
 }
+#endif // gsl_HAVE_WCHAR
 
 //
 // ensure_sentinel()

--- a/test/gsl-lite.t.hpp
+++ b/test/gsl-lite.t.hpp
@@ -48,6 +48,7 @@ inline std::ostream & operator<<( std::ostream & os, std::array<T,N> const & a )
 }
 #endif
 
+#if gsl_HAVE_WCHAR
 inline std::ostream & operator<<( std::ostream & os, std::wstring const & text )
 {
 #if ! gsl_BETWEEN( gsl_COMPILER_MSVC_VERSION, 6, 7 )
@@ -56,6 +57,7 @@ inline std::ostream & operator<<( std::ostream & os, std::wstring const & text )
     std::copy( text.begin(), text.end(), std::ostream_iterator<char>(os) ); return os;
 #endif
 }
+#endif // gsl_HAVE_WCHAR
 
 #if ! gsl_BETWEEN( gsl_COMPILER_MSVC_VERSION, 6, 7 )
 } // namespace std

--- a/test/lest_cpp03.hpp
+++ b/test/lest_cpp03.hpp
@@ -50,7 +50,11 @@
 #endif
 
 #ifndef  lest_FEATURE_TIME
-# define lest_FEATURE_TIME 1
+# if !(defined(__DJGPP__) && defined(__STRICT_ANSI__))
+#  define lest_FEATURE_TIME 1
+# else
+#  define lest_FEATURE_TIME 0
+# endif
 #endif
 
 #ifndef lest_FEATURE_TIME_PRECISION

--- a/test/string_span.t.cpp
+++ b/test/string_span.t.cpp
@@ -19,7 +19,9 @@
 
 #include <sstream>  // std::ostringstream
 #include <string.h> // strlen()
+#if gsl_HAVE_WCHAR
 #include <wchar.h>  // wcslen()
+#endif // gsl_HAVE_WCHAR
 
 typedef string_span::index_type index_type;
 
@@ -341,6 +343,7 @@ CASE( "string_span: Allows to construct a cstring_span from a const container, v
     EXPECT( std::equal( sv.begin(), sv.end(), vec.begin() ) );
 }
 
+#if gsl_HAVE_WCHAR
 CASE( "string_span: Allows to construct a wstring_span from a non-const C-string and size" )
 {
     wchar_t s[] = L"hello";
@@ -599,6 +602,7 @@ CASE( "string_span: Allows to construct a cwstring_span from a const container, 
     EXPECT( sv.length() == index_type( 9 ) );
     EXPECT( std::equal( sv.begin(), sv.end(), vec.begin() ) );
 }
+#endif // gsl_HAVE_WCHAR
 
 CASE( "string_span: Allows to copy-construct from another span of the same type" )
 {
@@ -1028,6 +1032,7 @@ CASE( "string_span: Allows to obtain the number of elements via size()" )
     EXPECT( sb.size() == index_type( strlen( b ) ) );
 }
 
+#if gsl_HAVE_WCHAR
 CASE( "string_span: Allows to obtain the number of bytes via length_bytes()" )
 {
     wchar_t a[] = L"hello";
@@ -1053,6 +1058,7 @@ CASE( "string_span: Allows to obtain the number of bytes via size_bytes()" )
     EXPECT( sa.size_bytes() == index_type( sizeof(wchar_t) * wcslen( a ) ) );
     EXPECT( sb.size_bytes() == index_type( sizeof(wchar_t) * wcslen( b ) ) );
 }
+#endif // gsl_HAVE_WCHAR
 
 CASE( "string_span: Allows to view the elements as read-only bytes" )
 {
@@ -1088,6 +1094,7 @@ CASE( "to_string(): Allows to explicitly convert from cstring_span to std::strin
     EXPECT( to_string( sv ) == s );
 }
 
+#if gsl_HAVE_WCHAR
 CASE( "to_string(): Allows to explicitly convert from wstring_span to std::wstring" )
 {
     wchar_t s[] = L"hello";
@@ -1109,6 +1116,7 @@ CASE( "to_string(): Allows to explicitly convert from cwstring_span to std::wstr
     EXPECT( ws.length() == 5u );
     EXPECT( std::equal( ws.begin(), ws.end(), s ) );
 }
+#endif // gsl_HAVE_WCHAR
 
 CASE( "ensure_z(): Disallows to build a string_span from a const C-string" )
 {
@@ -1122,6 +1130,7 @@ CASE( "ensure_z(): Disallows to build a string_span from a const C-string" )
 #endif
 }
 
+#if gsl_HAVE_WCHAR
 CASE( "ensure_z(): Disallows to build a wstring_span from a const wide C-string" )
 {
 #if gsl_CONFIG_CONFIRMS_COMPILATION_ERRORS
@@ -1133,6 +1142,7 @@ CASE( "ensure_z(): Disallows to build a wstring_span from a const wide C-string"
     EXPECT( std::wstring( sv.data() ) == std::wstring( s ) );
 #endif
 }
+#endif // gsl_HAVE_WCHAR
 
 CASE( "ensure_z(): Allows to build a string_span from a non-const C-string" )
 {
@@ -1175,6 +1185,7 @@ CASE( "ensure_z(): Allows to build a cstring_span from a const C-string" )
     EXPECT( std::string( sv.data() ) == s );
 }
 
+#if gsl_HAVE_WCHAR
 CASE( "ensure_z(): Allows to build a wstring_span from a non-const wide C-string" )
 {
     wchar_t s[] = L"hello";
@@ -1216,6 +1227,7 @@ CASE( "ensure_z(): Allows to build a cwstring_span from a const wide C-string" )
     EXPECT( sv.length() == index_type( 5 ) );
     EXPECT( std::wstring( sv.data() ) == std::wstring( s ) );
 }
+#endif // gsl_HAVE_WCHAR
 
 CASE( "ensure_z(): Allows to specify ultimate location of the sentinel and ensure its presence" )
 {
@@ -1252,6 +1264,7 @@ CASE ( "operator<<: Allows printing a cstring_span to an output stream" )
     EXPECT( oss.str() == "hello\n     hello\nhello\nhello....." );
 }
 
+#if gsl_HAVE_WCHAR
 CASE ( "operator<<: Allows printing a wstring_span to an output stream" )
 {
     std::wostringstream oss;
@@ -1279,5 +1292,6 @@ CASE ( "operator<<: Allows printing a cwstring_span to an output stream" )
 
     EXPECT( oss.str() == L"hello\n     hello\nhello\nhello....." );
 }
+#endif // gsl_HAVE_WCHAR
 
 // end of file


### PR DESCRIPTION
This compiler is GCC based and is targeting DOS. It does not support `wchar_t` nor `std::wstring` probably because there would not be much use of them in DOS.

All the tests and examples were tested on DOSBox and on FreeDOS using DJGPP for GCC 7.2.0 with success (actually there is one test failing in *cpp11 and in *cpp14 but you are probably aware of that).

Since DJGPP is a cross compiler, user has to supply cmake with `-DCMAKE_SYSTEM_NAME=Generic` to be able to build the project with it, see https://cmake.org/Wiki/CMake_Cross_Compiling.

Some relevant links regarding DJGPP cross compiler:
https://www.youtube.com/watch?v=yHrC_rZUaiA
https://github.com/andrewwutw/build-djgpp