### PR TITLE
Add a constructor to allow rvalue to const lvalue conversion

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -1324,9 +1324,21 @@ public:
         : first_( cont.data() )
         , last_ ( cont.data() + cont.size() )
     {}
+
+    template< class Cont, class = decltype(std::declval<Cont const &>().data()) >
+    gsl_api gsl_constexpr14 span( Cont const & cont )
+        : first_( cont.data() )
+        , last_ ( cont.data() + cont.size() )
+    {}
 #elif gsl_HAVE_UNCONSTRAINED_SPAN_CONTAINER_CTOR
     template< class Cont >
     gsl_api gsl_constexpr14 span( Cont & cont )
+        : first_( cont.size() == 0 ? gsl_nullptr : &cont[0] )
+        , last_ ( cont.size() == 0 ? gsl_nullptr : &cont[0] + cont.size() )
+    {}
+
+    template< class Cont >
+    gsl_api gsl_constexpr14 span( Cont const & cont )
         : first_( cont.size() == 0 ? gsl_nullptr : &cont[0] )
         , last_ ( cont.size() == 0 ? gsl_nullptr : &cont[0] + cont.size() )
     {}
@@ -1334,6 +1346,12 @@ public:
 
     template< class Cont >
     gsl_api gsl_constexpr14 span( with_container_t, Cont & cont )
+        : first_( cont.size() == 0 ? gsl_nullptr : &cont[0] )
+        , last_ ( cont.size() == 0 ? gsl_nullptr : &cont[0] + cont.size() )
+    {}
+
+    template< class Cont >
+    gsl_api gsl_constexpr14 span( with_container_t, Cont const & cont )
         : first_( cont.size() == 0 ? gsl_nullptr : &cont[0] )
         , last_ ( cont.size() == 0 ? gsl_nullptr : &cont[0] + cont.size() )
     {}
@@ -1855,7 +1873,7 @@ public:
             ! detail::is_std_array< Cont >::value
             && ! detail::is_basic_string_span< Cont >::value
             && std::is_convertible< typename Cont::pointer, pointer >::value
-            && std::is_convertible< typename Cont::pointer, decltype(std::declval<Cont>().data()) >::value
+            && std::is_convertible< typename Cont::pointer, decltype(std::declval<Cont const &>().data()) >::value
         >::type
     >
     gsl_api gsl_constexpr basic_string_span( Cont const & cont )

--- a/test/span.t.cpp
+++ b/test/span.t.cpp
@@ -19,6 +19,15 @@
 
 typedef span<int>::index_type index_type;
 
+static std::vector<int> vector_iota(int n)
+{
+  std::vector<int> ret;
+
+  for (int i = 0; i < n; ++i)
+    ret.push_back(i);
+  return ret;
+}
+
 CASE( "span<>: Disallows construction from a temporary value (C++11) (define gsl_CONFIG_CONFIRMS_COMPILATION_ERRORS)" )
 {
 #if gsl_CONFIG_CONFIRMS_COMPILATION_ERRORS
@@ -369,6 +378,17 @@ CASE( "span<>: Allows to construct from a container (std::vector<>)" )
 #endif
 }
 
+CASE( "span<>: Allows to construct from a temporary container (potentially dangerous)" )
+{
+#if gsl_HAVE_CONSTRAINED_SPAN_CONTAINER_CTOR || gsl_HAVE_UNCONSTRAINED_SPAN_CONTAINER_CTOR
+    std::vector<int> vec = vector_iota( 10 );
+
+    EXPECT( std::equal( vec.begin(), vec.end(), span<const int>( vector_iota(10) ).begin() ) );
+#else
+    EXPECT( !!"(un)constrained construction from container is not available" );
+#endif
+}
+
 CASE( "span<>: Allows to tag-construct from a container (std::vector<>)" )
 {
 # if gsl_HAVE_INITIALIZER_LIST
@@ -381,6 +401,14 @@ CASE( "span<>: Allows to tag-construct from a container (std::vector<>)" )
 
     EXPECT( std::equal( v.begin(), v.end(), vec.begin() ) );
     EXPECT( std::equal( w.begin(), w.end(), vec.begin() ) );
+}
+
+CASE( "span<>: Allows to tag-construct from a temporary container (potentially dangerous)" )
+{
+    std::vector<int> vec = vector_iota(10);
+
+    EXPECT( std::equal( vec.begin(), vec.end(), span<const int>( with_container, vector_iota( 10 ) ).begin() ) );
+    EXPECT( !!"std::array<> is not available (no C++11)" );
 }
 
 CASE( "span<>: Allows to construct from an empty gsl::shared_ptr (C++11)" )
@@ -1266,6 +1294,13 @@ CASE( "make_span(): Allows building from a const container (std::vector<>)" )
     span<const int> v = make_span( vec );
 
     EXPECT( std::equal( v.begin(), v.end(), vec.begin() ) );
+}
+
+CASE( "make_span(): Allows building from a temporary container (potentially dangerous)" )
+{
+    std::vector<int> vec = vector_iota(10);
+
+    EXPECT( std::equal( vec.begin(), vec.end(), make_span( vector_iota( 10 ) ).begin() ) );
 }
 
 CASE( "make_span(): Allows building from an empty gsl::shared_ptr (C++11)" )


### PR DESCRIPTION
This can be dangerous, but is motivated by the following use-case:

```cpp
std::vector<int> f();
void g(gsl::span<const int>);

g(f());
```

Fixes #113