### PR TITLE
Fix final_action_return and final_action_error during stack unwinding

### DIFF
--- a/test/util.t.cpp
+++ b/test/util.t.cpp
@@ -158,8 +158,12 @@ CASE( "on_return: Allows to perform action on leaving scope without exception (g
         static void fail() { try { final_action_return _ = on_return( &F::incr );   throw std::exception();   } catch (...) {} }
     };
 #endif
+    struct G {
+        ~G() { F::pass(); }
+    };
     { g_i = 0; F::pass(); EXPECT( g_i == 1 ); }
     { g_i = 0; F::fail(); EXPECT( g_i == 0 ); }
+    { g_i = 0; try { G g; throw std::exception(); } catch (...) {}; EXPECT( g_i == 1 ); }
 #else
     EXPECT( !!"on_return not available (no gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD)" );
 #endif
@@ -181,8 +185,12 @@ CASE( "on_error: Allows to perform action on leaving scope via an exception (gsl
         static void fail() { try { final_action_error _ = on_error( &F::incr );   throw std::exception();   } catch (...) {} }
     };
 #endif
+    struct G {
+        ~G() { F::pass(); }
+    };
     { g_i = 0; F::pass(); EXPECT( g_i == 0 ); }
     { g_i = 0; F::fail(); EXPECT( g_i == 1 ); }
+    { g_i = 0; try { G g; throw std::exception(); } catch (...) {}; EXPECT( g_i == 0 ); }
 #else
     EXPECT( !!"on_error not available (no gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD)" );
 #endif


### PR DESCRIPTION
Previously they would always take the error path, even when there is no exception in the guarded function. This is the reason why std::uncaught_exception was deprecated in favour of uncaught_exceptions, there's a paper about it here: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4152.pdf
I've added uncaught_exceptions for pre-2017 MSVC, GCC and Clang which is basically the same as the one used here: https://github.com/evgeny-panasyuk/stack_unwinding/blob/master/boost/exception/uncaught_exception_count.hpp
That version has been tested with a number of compiler versions.