### PR TITLE
Workaround for misleading __cplusplus

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -141,10 +141,12 @@
 // C++ language version detection (C++20 is speculative):
 // Note: VC14.0/1900 (VS2015) lacks too much from C++14.
 
-#if defined _MSVC_LANG
-# define gsl_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
-#else
-# define gsl_CPLUSPLUS  __cplusplus
+#ifndef gsl_CPLUSPLUS
+# if defined _MSVC_LANG
+#  define gsl_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
+# else
+#  define gsl_CPLUSPLUS  __cplusplus
+# endif
 #endif
 
 #define gsl_CPP98_OR_GREATER  ( gsl_CPLUSPLUS >= 199711L )


### PR DESCRIPTION
GCC didn't set the __cplusplus symbol correctly till version 4.7.0: https://stackoverflow.com/questions/2324658/how-to-determine-the-version-of-the-c-standard-used-by-the-compiler/7132549#7132549