### PR TITLE
Device code compatible fail_fast_assert

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -793,8 +793,12 @@ gsl_api inline void fail_fast_assert( bool cond, char const * const expression, 
 
 gsl_api inline void fail_fast_assert( bool cond ) gsl_noexcept
 {
+#ifdef __CUDA_ARCH__
+    assert(cond);
+#else // __CUDA_ARCH__
     if ( !cond )
         std::terminate();
+#endif // __CUDA_ARCH__
 }
 
 # endif


### PR DESCRIPTION
This also enables the usage of gsl::span objects in device code. The assert in the device code can easily be traced with `cuda-gdb`.