### PR TITLE
Add audit-level and assume-level contract checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
 
 project(
     gsl_lite
-    VERSION 0.34.0
+    VERSION 0.35.0
 #   DESCRIPTION "A single-file header-only version of ISO C++ Guideline Support Library (GSL) for C++98, C++11 and later"
 #   HOMEPAGE_URL "https://github.com/martinmoene/gsl-lite"
     LANGUAGES CXX )

--- a/README.md
+++ b/README.md
@@ -356,13 +356,13 @@ auto median( It first, It last )
 ```
 
 
-It is possible to selectively disable either pre- or postcondition checking with the following macros:
+It is possible to enable only precondition or only postcondition checking with one of the following macros:
 
 \-D<b>gsl\_CONFIG_CONTRACT\_EXPECTS\_ONLY</b>  
-Define this macro to disable all runtime checking and evaluation of postcondition contracts.
+Define this macro to permit runtime checking and evaluation for precondition contracts only.
 
 \-D<b>gsl\_CONFIG\_CONTRACT\_ENSURES\_ONLY</b>  
-Define this macro to disable all runtime checking and evaluation of precondition contracts.
+Define this macro to permit runtime checking and evaluation for postcondition contracts only.
 
 
 The following macros control the handling of runtime contract violations:

--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ The following features are deprecated since the indicated version. See macro [`g
 
 Version | Level | Feature / Notes |
 -------:|:-----:|:----------------|
+0.35.0  |   -   | `gsl_CONFIG_CONTRACT_LEVEL_EXPECTS_ONLY` and `gsl_CONFIG_CONTRACT_LEVEL_ENSURES_ONLY` |
+&nbsp;  |&nbsp; | Use `gsl_CONFIG_CONTRACT_EXPECTS_ONLY`/`gsl_CONFIG_CONTRACT_ENSURES_ONLY` |
 0.31.0  |   5   | span( std::nullptr_t, index_type ) |
 &nbsp;  |&nbsp; | span( pointer, index_type ) is used |
 0.31.0  |   5   | span( U *, index_type size ) |
@@ -524,8 +526,8 @@ Version | Level | Feature / Notes |
 &nbsp;  |&nbsp; | Use span::size_bytes() |
 0.17.0  |   2   | member span::as_bytes(), span::as_writeable_bytes() |
 &nbsp;  |&nbsp; | &mdash; |
-0.7.0   |   1   | gsl_CONFIG_ALLOWS_SPAN_CONTAINER_CTOR |
-&nbsp;  |&nbsp; | Use gsl_CONFIG_ALLOWS_UNCONSTRAINED_SPAN_CONTAINER_CTOR,<br>or consider span(with_container, cont). |
+0.7.0   |   -   | `gsl_CONFIG_ALLOWS_SPAN_CONTAINER_CTOR` |
+&nbsp;  |&nbsp; | Use `gsl_CONFIG_ALLOWS_UNCONSTRAINED_SPAN_CONTAINER_CTOR`,<br>or consider span(with_container, cont). |
 
 
 Reported to work with

--- a/README.md
+++ b/README.md
@@ -298,28 +298,47 @@ Provide experimental types `final_action_return` and `final_action_error` and co
 
 ### Contract violation response macros
 
-*gsl-lite* provides contract violation response control as suggested in proposal [N4415](http://wg21.link/n4415).
+*gsl-lite* provides contract violation response control as originally suggested in proposal [N4415](http://wg21.link/n4415), with some refinements inspired by [P1710](http://wg21.link/P1710)/[P1730](http://wg21.link/P1730).
 
+There are four macros for expressing pre- and postconditions:
+
+- `Expects` for simple preconditions
+- `Ensures` for simple postconditions
+- `ExpectsAudit` for preconditions that are expensive or include potentially opaque function calls
+- `EnsuresAudit` for postconditions that are expensive or include potentially opaque function calls
+
+
+The contract checking level can be controlled by defining one of the following macros:
+
+\-D<b>gsl\_CONFIG\_CONTRACT\_LEVEL\_AUDIT</b>  
+Define this macro to have all contracts checked at runtime.
+ 
 \-D<b>gsl\_CONFIG\_CONTRACT\_LEVEL\_ON</b>  
-Define this macro to include both `Expects` and `Ensures` in the code. This is the default case.
+Define this macro to have contracts expressed with `Expects` and `Ensures` checked at runtime, and contracts expressed with `ExpectsAudit` and `EnsuresAudit` not checked and not evaluated at runtime. This is the default case.
  
 \-D<b>gsl\_CONFIG\_CONTRACT\_LEVEL\_OFF</b>  
-Define this macro to exclude both `Expects` and `Ensures` from the code.
+Define this macro to disable all runtime checking and evaluation of contracts.
 
-\-D<b>gsl\_CONFIG_CONTRACT\_LEVEL\_EXPECTS\_ONLY</b>  
-Define this macro to include `Expects` in the code and exclude `Ensures` from the code.
 
-\-D<b>gsl\_CONFIG\_CONTRACT\_LEVEL\_ENSURES\_ONLY</b>  
-Define this macro to exclude `Expects` from the code and include `Ensures` in the code.
+It is possible to selectively disable either pre- or postcondition checking with the following macros:
+
+\-D<b>gsl\_CONFIG_CONTRACT\_EXPECTS\_ONLY</b>  
+Define this macro to disable all runtime checking and evaluation of postcondition contracts.
+
+\-D<b>gsl\_CONFIG\_CONTRACT\_ENSURES\_ONLY</b>  
+Define this macro to disable all runtime checking and evaluation of precondition contracts.
+
+
+The following macros control the handling of runtime contract violations:
 
 \-D<b>gsl\_CONFIG\_CONTRACT\_VIOLATION\_TERMINATES</b>  
-Define this macro to call `std::terminate()` on a GSL contract violation in `Expects`, `Ensures` and `narrow`. This is the default case.
+Define this macro to call `std::terminate()` on a GSL contract violation in `Expects`, `ExpectsAudit`, `Ensures`, `EnsuresAudit`, and `narrow`. This is the default case.
 
 \-D<b>gsl\_CONFIG\_CONTRACT\_VIOLATION\_THROWS</b>  
-Define this macro to throw a std::runtime_exception-derived exception `gsl::fail_fast` instead of calling `std::terminate()` on a GSL contract violation in `Expects`, `Ensures` and throw a std::exception-derived exception `narrowing_error` on discarding  information in `narrow`.
+Define this macro to throw a std::runtime_exception-derived exception `gsl::fail_fast` instead of calling `std::terminate()` on a GSL contract violation in `Expects`, `ExpectsAudit`, `Ensures`, `EnsuresAudit`, and throw a std::exception-derived exception `narrowing_error` on discarding information in `narrow`.
 
 \-D<b>gsl\_CONFIG\_CONTRACT\_VIOLATION\_CALLS\_HANDLER</b>  
-Define this macro to call a user-defined handler function `gsl::fail_fast_assert_handler()` instead of calling `std::terminate()` on a GSL contract violation in `Expects` and `Ensures`, and call `std::terminate()` on discarding  information in `narrow`. The user is expected to supply a definition matching the following signature:
+Define this macro to call a user-defined handler function `gsl::fail_fast_assert_handler()` instead of calling `std::terminate()` on a GSL contract violation in `Expects`, `ExpectsAudit`, `Ensures`, and `EnsuresAudit`, and call `std::terminate()` on discarding information in `narrow`. The user is expected to supply a definition matching the following signature:
 
 ```Cpp
 namespace gsl {
@@ -415,6 +434,8 @@ at()                        | -       | -       | < C++11 | static arrays, std::
 **3. Assertions**           | &nbsp;  | &nbsp;  | &nbsp;  | &nbsp; |
 Expects()                   | &#10003;| &#10003;| &#10003;| Precondition assertion |
 Ensures()                   | &#10003;| &#10003;| &#10003;| Postcondition assertion |
+ExpectsAudit()              | -       | -       | &#10003;| Audit-level precondition assertion |
+EnsuresAudit()              | -       | -       | &#10003;| Audit-level postcondition assertion |
 **4. Utilities**            | &nbsp;  | &nbsp;  | &nbsp;  | &nbsp; |
 index                       | &#10003;| &#10003;| &#10003;| type for container indexes, subscripts, sizes,<br>see [Other configuration macros](#other-configuration-macros) |
 byte                        | -       | &#10003;| &#10003;| byte type, see also proposal [p0298](http://wg21.link/p0298) |

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -757,8 +757,14 @@ typedef gsl_CONFIG_SPAN_INDEX_TYPE index;   // p0122r3 uses std::ptrdiff_t
 #define gsl_ELIDE_CONTRACT_EXPECTS_AUDIT  ( 0 == ( gsl_CONFIG_CONTRACT_LEVEL_MASK & 0x02 ) )
 #define gsl_ELIDE_CONTRACT_ENSURES_AUDIT  ( 0 == ( gsl_CONFIG_CONTRACT_LEVEL_MASK & 0x20 ) )
 
+#if gsl_HAVE( TYPE_TRAITS )
+# define gsl_ELIDE_CONTRACT( x )  static_assert(::std::is_convertible<decltype(( x )), bool>::value, "argument of contract check must be convertible to bool")
+#else
+# define gsl_ELIDE_CONTRACT( x )
+#endif
+
 #if gsl_ELIDE_CONTRACT_EXPECTS
-# define Expects( x )  /* Expects elided */
+# define Expects( x )  gsl_ELIDE_CONTRACT( x )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_THROWS_V )
 # define Expects( x )  ::gsl::fail_fast_assert( (x), "GSL: Precondition failure at " __FILE__ ":" gsl_STRINGIFY(__LINE__) )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_CALLS_HANDLER_V )
@@ -767,14 +773,8 @@ typedef gsl_CONFIG_SPAN_INDEX_TYPE index;   // p0122r3 uses std::ptrdiff_t
 # define Expects( x )  ::gsl::fail_fast_assert( (x) )
 #endif
 
-#if gsl_ELIDE_CONTRACT_EXPECTS
-# define gsl_EXPECTS_UNUSED_PARAM( x )  /* Make param unnamed if Expects elided */
-#else
-# define gsl_EXPECTS_UNUSED_PARAM( x )  x
-#endif
-
 #if gsl_ELIDE_CONTRACT_EXPECTS_AUDIT
-# define ExpectsAudit( x )  /* ExpectsAudit elided */
+# define ExpectsAudit( x )  gsl_ELIDE_CONTRACT( x )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_THROWS_V )
 # define ExpectsAudit( x )  ::gsl::fail_fast_assert( (x), "GSL: Precondition failure at " __FILE__ ":" gsl_STRINGIFY(__LINE__) )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_CALLS_HANDLER_V )
@@ -784,7 +784,7 @@ typedef gsl_CONFIG_SPAN_INDEX_TYPE index;   // p0122r3 uses std::ptrdiff_t
 #endif
 
 #if gsl_ELIDE_CONTRACT_ENSURES
-# define Ensures( x )  /* Ensures elided */
+# define Ensures( x )  gsl_ELIDE_CONTRACT( x )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_THROWS_V )
 # define Ensures( x )  ::gsl::fail_fast_assert( (x), "GSL: Postcondition failure at " __FILE__ ":" gsl_STRINGIFY(__LINE__) )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_CALLS_HANDLER_V )
@@ -794,7 +794,7 @@ typedef gsl_CONFIG_SPAN_INDEX_TYPE index;   // p0122r3 uses std::ptrdiff_t
 #endif
 
 #if gsl_ELIDE_CONTRACT_ENSURES_AUDIT
-# define EnsuresAudit( x )  /* EnsuresAudit elided */
+# define EnsuresAudit( x )  gsl_ELIDE_CONTRACT( x )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_THROWS_V )
 # define EnsuresAudit( x )  ::gsl::fail_fast_assert( (x), "GSL: Postcondition failure at " __FILE__ ":" gsl_STRINGIFY(__LINE__) )
 #elif gsl_CONFIG( CONTRACT_VIOLATION_CALLS_HANDLER_V )
@@ -1631,7 +1631,7 @@ public:
 #if ! gsl_DEPRECATE_TO_LEVEL( 5 )
 
 #if gsl_HAVE( NULLPTR )
-    gsl_api gsl_constexpr14 span( std::nullptr_t, index_type gsl_EXPECTS_UNUSED_PARAM( size_in ) )
+    gsl_api gsl_constexpr14 span( std::nullptr_t, index_type size_in )
         : first_( nullptr )
         , last_ ( nullptr )
     {


### PR DESCRIPTION
This PR introduces the new macros `ExpectsAudit` and `EnsuresAudit` and the configuration macros `gsl_CONFIG_CONTRACT_LEVEL_AUDIT` and `gsl_CONFIG_CONTRACT_LEVEL_ASSUME` to implement audit-level and assume-level contract checking as proposed in #168.

It also deprecates the levels `gsl_CONFIG_CONTRACT_LEVEL_{EXPECTS|ENSURES}_ONLY` in favor of the new configuration macros `gsl_CONFIG_CONTRACT_{EXPECTS|ENSURES}_ONLY` which are orthogonal to the contract checking level.

Closes #168
Closes #70
