### PR TITLE
Fix warnings

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,6 +72,7 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang" )
 
     set( OPTIONS
         -O2
+        -Werror
         -Wall
         -Wno-missing-braces
         -Wconversion

--- a/test/assert.t.cpp
+++ b/test/assert.t.cpp
@@ -80,7 +80,7 @@ int testAssume( int i, std::vector<int> const& v )
 {
     // This should compile without warnings.
     gsl_ASSUME( i >= 0 && static_cast<std::size_t>(i) < v.size() );
-    return v.at( i );
+    return v.at( static_cast<std::size_t>(i) );
 }
 
 // end of file

--- a/test/gsl-lite.t.hpp
+++ b/test/gsl-lite.t.hpp
@@ -29,11 +29,15 @@
 // Compiler warning suppression for usage of lest:
 
 #ifdef __clang__
+# pragma clang diagnostic ignored "-Wunknown-pragmas" // don't warn if any of the following warnings are introduced later than the current compiler version
+# pragma clang diagnostic ignored "-Wunknown-warning-option" // see above, but for newer compilers
 # pragma clang diagnostic ignored "-Wstring-conversion"
 # pragma clang diagnostic ignored "-Wunused-parameter"
 # pragma clang diagnostic ignored "-Wunused-template"
 # pragma clang diagnostic ignored "-Wunused-function"
 # pragma clang diagnostic ignored "-Wunused-member-function"
+# pragma clang diagnostic warning "-Wunknown-warning-option" // we want to see warnings about unknown warning options
+# pragma clang diagnostic warning "-Wunknown-pragmas" // we want to see warnings about unknown pragmas
 #elif defined __GNUC__
 # pragma GCC   diagnostic ignored "-Wunused-parameter"
 # pragma GCC   diagnostic ignored "-Wunused-function"


### PR DESCRIPTION
Fix currently present gcc/clang warnings, and turn all warnings to errors.

Note: the comment relating to the warning in issue #195 is not modified in this PR, I leave that to @mbeutel, but the warning is fixed.