### PR TITLE
Add CMake targets for versioned defaults; add `gsl_CONFIG_INDEX_TYPE`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,4 @@
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
+out/
+build*/
+.vs/
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,18 +68,51 @@ include( CMakePackageConfigHelpers )
 
 add_library(
     ${package_name} INTERFACE )
-
 add_library(
     ${package_nspace}::${package_name} ALIAS ${package_name} )
-
 target_include_directories(
     ${package_name}
     INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
-
 target_sources(
     ${package_name}
+    INTERFACE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gsl-lite.natvis>" )
+
+# Interface library for targets with versioned defaults:
+
+# "gsl-lite-v0" target for legacy defaults:
+add_library(
+    ${package_name}-v0 INTERFACE )
+add_library(
+    ${package_nspace}::${package_name}-v0 ALIAS ${package_name}-v0 )
+target_include_directories(
+    ${package_name}-v0
+    INTERFACE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
+target_sources(
+    ${package_name}-v0
+    INTERFACE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gsl-lite.natvis>" )
+
+# "gsl-lite-v1" target for modern defaults:
+add_library(
+    ${package_name}-v1 INTERFACE )
+add_library(
+    ${package_nspace}::${package_name}-v1 ALIAS ${package_name}-v1 )
+target_include_directories(
+    ${package_name}-v1
+    INTERFACE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
+target_compile_definitions(
+    ${package_name}-v1
+    INTERFACE
+        gsl_lite_DEFAULTS_VERSION=1)
+target_sources(
+    ${package_name}-v1
     INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gsl-lite.natvis>" )
 
@@ -106,7 +139,7 @@ configure_file(
 # Installation:
 
 install(
-    TARGETS      ${package_name}
+    TARGETS      ${package_name} ${package_name}-v0 ${package_name}-v1
     EXPORT       ${package_target}
 #   INCLUDES DESTINATION "${...}"  # already set via target_include_directories()
 )

--- a/README.md
+++ b/README.md
@@ -409,8 +409,11 @@ Equivalent to -Dgsl\_CONFIG\_CONTRACT\_VIOLATION\_TERMINATES.
 \-D<b>gsl\_CONFIG\_DEPRECATE\_TO\_LEVEL</b>=0  
 Define this to and including the level you want deprecation; see table [Deprecation](#deprecation) below. Default is 0 for no deprecation.
 
+\-D<b>gsl\_CONFIG\_INDEX\_TYPE</b>=size_t  
+Define this macro to the type to use for `gsl::index`. Microsoft's GSL uses `std::ptrdiff_t`. Default for *gsl-lite* is `size_t`.
+
 \-D<b>gsl\_CONFIG\_SPAN\_INDEX\_TYPE</b>=size_t  
-Define this macro to the type to use for indices in `span` and `basic_string_span`. Microsoft's GSL uses `std::ptrdiff_t`. Default for *gsl lite* is `size_t`.
+Define this macro to the type to use for indices in `span` and `basic_string_span`. Microsoft's GSL uses `std::ptrdiff_t`. Default for *gsl-lite* is `size_t`.
 
 \-D<b>gsl\_CONFIG\_NOT\_NULL\_EXPLICIT\_CTOR</b>=0  
 Define this macro to 1 to make `not_null`'s constructor explicit. Default is 0. Note that in Microsoft's GSL the constructor is explicit. For implicit construction you can also use the *gsl lite*-specific `not_null`-derived class `not_null_ic`.

--- a/gsl-lite.natvis
+++ b/gsl-lite.natvis
@@ -41,6 +41,9 @@
   </Type>
 
   <Type Name="gsl::not_null&lt;*&gt;">
-    <DisplayString>value = {*ptr_}</DisplayString>
+      <DisplayString>{data_.ptr_}</DisplayString>
+      <Expand>
+          <ExpandedItem>data_.ptr_</ExpandedItem>
+      </Expand>
   </Type>
 </AutoVisualizer>

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -38,6 +38,10 @@
 
 // gsl-lite backward compatibility:
 
+#if !defined( gsl_CONFIG_DEFAULTS_VERSION )
+# define gsl_CONFIG_DEFAULTS_VERSION gsl_lite_MAJOR
+#endif
+
 #ifdef gsl_CONFIG_ALLOWS_SPAN_CONTAINER_CTOR
 # define gsl_CONFIG_ALLOWS_UNCONSTRAINED_SPAN_CONTAINER_CTOR  gsl_CONFIG_ALLOWS_SPAN_CONTAINER_CTOR
 # pragma message ("gsl_CONFIG_ALLOWS_SPAN_CONTAINER_CTOR is deprecated since gsl-lite 0.7.0; replace with gsl_CONFIG_ALLOWS_UNCONSTRAINED_SPAN_CONTAINER_CTOR, or consider span(with_container, cont).")
@@ -94,7 +98,7 @@
 #endif
 
 #ifndef  gsl_FEATURE_OWNER_MACRO
-# define gsl_FEATURE_OWNER_MACRO  1
+# define gsl_FEATURE_OWNER_MACRO  (gsl_CONFIG_DEFAULTS_VERSION == 0)
 #endif
 
 #ifndef  gsl_FEATURE_EXPERIMENTAL_RETURN_GUARD
@@ -112,11 +116,11 @@
 #endif
 
 #ifndef  gsl_CONFIG_SPAN_INDEX_TYPE
-# define gsl_CONFIG_SPAN_INDEX_TYPE  size_t
+# define gsl_CONFIG_SPAN_INDEX_TYPE  std::size_t
 #endif
 
 #ifndef  gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR
-# define gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR  0
+# define gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR  (gsl_CONFIG_DEFAULTS_VERSION >= 1)
 #endif
 
 #ifndef  gsl_CONFIG_NOT_NULL_GET_BY_CONST_REF
@@ -124,7 +128,7 @@
 #endif
 
 #ifndef  gsl_CONFIG_TRANSPARENT_NOT_NULL
-# define gsl_CONFIG_TRANSPARENT_NOT_NULL  0
+# define gsl_CONFIG_TRANSPARENT_NOT_NULL  (gsl_CONFIG_DEFAULTS_VERSION >= 1)
 #endif
 
 #ifndef  gsl_CONFIG_CONFIRMS_COMPILATION_ERRORS
@@ -132,7 +136,7 @@
 #endif
 
 #ifndef  gsl_CONFIG_ALLOWS_NONSTRICT_SPAN_COMPARISON
-# define gsl_CONFIG_ALLOWS_NONSTRICT_SPAN_COMPARISON  1
+# define gsl_CONFIG_ALLOWS_NONSTRICT_SPAN_COMPARISON  (gsl_CONFIG_DEFAULTS_VERSION == 0)
 #endif
 
 #ifndef  gsl_CONFIG_ALLOWS_UNCONSTRAINED_SPAN_CONTAINER_CTOR

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -119,6 +119,14 @@
 # define gsl_CONFIG_SPAN_INDEX_TYPE  std::size_t
 #endif
 
+#ifndef  gsl_CONFIG_INDEX_TYPE
+# if gsl_CONFIG_DEFAULTS_VERSION >= 1
+#  define gsl_CONFIG_INDEX_TYPE  std::ptrdiff_t
+# else
+#  define gsl_CONFIG_INDEX_TYPE  gsl_CONFIG_SPAN_INDEX_TYPE
+# endif
+#endif
+
 #ifndef  gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR
 # define gsl_CONFIG_NOT_NULL_EXPLICIT_CTOR  (gsl_CONFIG_DEFAULTS_VERSION >= 1)
 #endif
@@ -824,7 +832,7 @@ struct is_compatible_container : std::true_type{};
 //
 
 // index type for all container indexes/subscripts/sizes
-typedef gsl_CONFIG_SPAN_INDEX_TYPE index;   // p0122r3 uses std::ptrdiff_t
+typedef gsl_CONFIG_INDEX_TYPE index;   // p0122r3 uses std::ptrdiff_t
 
 //
 // GSL.owner: ownership pointers
@@ -2148,7 +2156,7 @@ class span
     template< class U > friend class span;
 
 public:
-    typedef index index_type;
+    typedef gsl_CONFIG_SPAN_INDEX_TYPE index_type;
 
     typedef T element_type;
     typedef typename std11::remove_cv< T >::type value_type;

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -517,14 +517,15 @@
 #endif
 
 // Suppress the following MSVC GSL warnings:
+// - C26432: gsl::c.21 : if you define or delete any default operation in the type '...', define or delete them all
 // - C26410: gsl::r.32 : the parameter 'ptr' is a reference to const unique pointer, use const T* or const T& instead
 // - C26415: gsl::r.30 : smart pointer parameter 'ptr' is used only to access contained pointer. Use T* or T& instead
 // - C26418: gsl::r.36 : shared pointer parameter 'ptr' is not copied or moved. Use T* or T& instead
-// - C26455: gsl::f.6  : default constructor may not throw. Declare it 'noexcept'
 // - C26472: gsl::t.1  : don't use a static_cast for arithmetic conversions;
 //                       use brace initialization, gsl::narrow_cast or gsl::narrow
 // - C26439: gsl::f.6  : special function 'function' can be declared 'noexcept'
 // - C26440: gsl::f.6  : function 'function' can be declared 'noexcept'
+// - C26455: gsl::f.6  : default constructor may not throw. Declare it 'noexcept'
 // - C26473: gsl::t.1  : don't cast between pointer types where the source type and the target type are the same
 // - C26481: gsl::b.1  : don't use pointer arithmetic. Use span instead
 // - C26482: gsl::b.2  : only index into arrays using constant expressions
@@ -532,7 +533,7 @@
 // - C26490: gsl::t.1  : don't use reinterpret_cast
 // - C26487: gsl::l.4  : don't return a pointer '(<some number>'s result)' that may be invalid
 
-gsl_DISABLE_MSVC_WARNINGS( 26410 26415 26418 26472 26439 26440 26473 26481 26482 26446 26490 26487 )
+gsl_DISABLE_MSVC_WARNINGS( 26432 26410 26415 26418 26472 26439 26440 26455 26473 26481 26482 26446 26490 26487 )
 
 namespace gsl {
 
@@ -2144,9 +2145,9 @@ gsl_api inline gsl_constexpr byte operator~( byte b ) gsl_noexcept
 
 #if gsl_FEATURE_TO_STD( WITH_CONTAINER )
 
-// Tag to select span constructor taking a container (prevent ms-gsl warning C26426):
+// Tag to select span constructor taking a container:
 
-struct with_container_t { gsl_constexpr with_container_t() gsl_noexcept {} };
+struct with_container_t { };
 const  gsl_constexpr   with_container_t with_container;
 
 #endif

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -509,6 +509,7 @@
 # define gsl_DISABLE_MSVC_WARNINGS(codes)        __pragma(warning(push))  __pragma(warning(disable: codes))
 # define gsl_RESTORE_MSVC_WARNINGS()             __pragma(warning(pop ))
 #else
+// TODO: define for Clang
 # define gsl_SUPPRESS_MSGSL_WARNING(expr)
 # define gsl_SUPPRESS_MSVC_WARNING(code, descr)
 # define gsl_DISABLE_MSVC_WARNINGS(codes)
@@ -516,19 +517,20 @@
 #endif
 
 // Suppress the following MSVC GSL warnings:
-// - C26410: gsl::r.32: the parameter 'ptr' is a reference to const unique pointer, use const T* or const T& instead
-// - C26415: gsl::r.30: smart pointer parameter 'ptr' is used only to access contained pointer. Use T* or T& instead
-// - C26418: gsl::r.36: shared pointer parameter 'ptr' is not copied or moved. Use T* or T& instead
-// - C26472: gsl::t.1 : don't use a static_cast for arithmetic conversions;
-//                      use brace initialization, gsl::narrow_cast or gsl::narow
-// - C26439: gsl::f.6 : special function 'function' can be declared 'noexcept'
-// - C26440: gsl::f.6 : function 'function' can be declared 'noexcept'
-// - C26473: gsl::t.1 : don't cast between pointer types where the source type and the target type are the same
-// - C26481: gsl::b.1 : don't use pointer arithmetic. Use span instead
-// - C26482: gsl::b.2 : only index into arrays using constant expressions
-// - C26446: gdl::b.4 : prefer to use gsl::at() instead of unchecked subscript operator
-// - C26490: gsl::t.1 : don't use reinterpret_cast
-// - C26487: gsl::l.4 : don't return a pointer '(<some number>'s result)' that may be invalid
+// - C26410: gsl::r.32 : the parameter 'ptr' is a reference to const unique pointer, use const T* or const T& instead
+// - C26415: gsl::r.30 : smart pointer parameter 'ptr' is used only to access contained pointer. Use T* or T& instead
+// - C26418: gsl::r.36 : shared pointer parameter 'ptr' is not copied or moved. Use T* or T& instead
+// - C26455: gsl::f.6  : default constructor may not throw. Declare it 'noexcept'
+// - C26472: gsl::t.1  : don't use a static_cast for arithmetic conversions;
+//                       use brace initialization, gsl::narrow_cast or gsl::narrow
+// - C26439: gsl::f.6  : special function 'function' can be declared 'noexcept'
+// - C26440: gsl::f.6  : function 'function' can be declared 'noexcept'
+// - C26473: gsl::t.1  : don't cast between pointer types where the source type and the target type are the same
+// - C26481: gsl::b.1  : don't use pointer arithmetic. Use span instead
+// - C26482: gsl::b.2  : only index into arrays using constant expressions
+// - C26446: gdl::b.4  : prefer to use gsl::at() instead of unchecked subscript operator
+// - C26490: gsl::t.1  : don't use reinterpret_cast
+// - C26487: gsl::l.4  : don't return a pointer '(<some number>'s result)' that may be invalid
 
 gsl_DISABLE_MSVC_WARNINGS( 26410 26415 26418 26472 26439 26440 26473 26481 26482 26446 26490 26487 )
 
@@ -1058,6 +1060,7 @@ public:
         other.invoke_ = false;
     }
 
+    gsl_SUPPRESS_MSGSL_WARNING(f.6)
     gsl_api virtual ~final_action() gsl_noexcept
     {
         if ( invoke_ )
@@ -1769,6 +1772,7 @@ public:
 #endif
 
 gsl_is_delete_access:
+    gsl_api not_null() gsl_is_delete;
     // prevent compilation when initialized with a nullptr or literal 0:
 #if gsl_HAVE( NULLPTR )
     gsl_api not_null(             std::nullptr_t ) gsl_is_delete;
@@ -2603,6 +2607,7 @@ span( Container const & ) -> span<const typename Container::value_type>;
 #if gsl_CONFIG( ALLOWS_NONSTRICT_SPAN_COMPARISON )
 
 template< class T, class U >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr bool operator==( span<T> const & l, span<U> const & r )
 {
     return  l.size()  == r.size()
@@ -2610,6 +2615,7 @@ gsl_api inline gsl_constexpr bool operator==( span<T> const & l, span<U> const &
 }
 
 template< class T, class U >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr bool operator< ( span<T> const & l, span<U> const & r )
 {
     return std::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
@@ -2618,6 +2624,7 @@ gsl_api inline gsl_constexpr bool operator< ( span<T> const & l, span<U> const &
 #else
 
 template< class T >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr bool operator==( span<T> const & l, span<T> const & r )
 {
     return  l.size()  == r.size()
@@ -2625,6 +2632,7 @@ gsl_api inline gsl_constexpr bool operator==( span<T> const & l, span<T> const &
 }
 
 template< class T >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr bool operator< ( span<T> const & l, span<T> const & r )
 {
     return std::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );
@@ -3178,6 +3186,7 @@ private:
 #if gsl_CONFIG( ALLOWS_NONSTRICT_SPAN_COMPARISON )
 
 template< class T, class U >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr14 bool operator==( basic_string_span<T> const & l, U const & u ) gsl_noexcept
 {
     const basic_string_span< typename std11::add_const<T>::type > r( u );
@@ -3187,6 +3196,7 @@ gsl_api inline gsl_constexpr14 bool operator==( basic_string_span<T> const & l, 
 }
 
 template< class T, class U >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr14 bool operator<( basic_string_span<T> const & l, U const & u ) gsl_noexcept
 {
     const basic_string_span< typename std11::add_const<T>::type > r( u );
@@ -3199,6 +3209,7 @@ gsl_api inline gsl_constexpr14 bool operator<( basic_string_span<T> const & l, U
 template< class T, class U
     gsl_REQUIRES_A_(( !detail::is_basic_string_span<U>::value ))
 >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr14 bool operator==( U const & u, basic_string_span<T> const & r ) gsl_noexcept
 {
     const basic_string_span< typename std11::add_const<T>::type > l( u );
@@ -3210,6 +3221,7 @@ gsl_api inline gsl_constexpr14 bool operator==( U const & u, basic_string_span<T
 template< class T, class U
     gsl_REQUIRES_A_(( !detail::is_basic_string_span<U>::value ))
 >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr14 bool operator<( U const & u, basic_string_span<T> const & r ) gsl_noexcept
 {
     const basic_string_span< typename std11::add_const<T>::type > l( u );
@@ -3221,6 +3233,7 @@ gsl_api inline gsl_constexpr14 bool operator<( U const & u, basic_string_span<T>
 #else //gsl_CONFIG( ALLOWS_NONSTRICT_SPAN_COMPARISON )
 
 template< class T >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr14 bool operator==( basic_string_span<T> const & l, basic_string_span<T> const & r ) gsl_noexcept
 {
     return l.size() == r.size()
@@ -3228,6 +3241,7 @@ gsl_api inline gsl_constexpr14 bool operator==( basic_string_span<T> const & l, 
 }
 
 template< class T >
+gsl_SUPPRESS_MSGSL_WARNING(stl.1)
 gsl_api inline gsl_constexpr14 bool operator<( basic_string_span<T> const & l, basic_string_span<T> const & r ) gsl_noexcept
 {
     return std::lexicographical_compare( l.begin(), l.end(), r.begin(), r.end() );

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -2147,7 +2147,7 @@ gsl_api inline gsl_constexpr byte operator~( byte b ) gsl_noexcept
 
 // Tag to select span constructor taking a container:
 
-struct with_container_t { };
+struct with_container_t { gsl_constexpr with_container_t() gsl_noexcept {} };
 const  gsl_constexpr   with_container_t with_container;
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,15 +61,12 @@ if( MSVC )
 
     set( HAS_STD_FLAGS TRUE )
 
-    set( OPTIONS     -EHsc -WX )
+    set( OPTIONS     -EHsc -W3 -WX )
     set( DEFINITIONS -D_SCL_SECURE_NO_WARNINGS )
 
     if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.00 )
-        set( OPTIONS    ${OPTIONS} -W4 )
         set( HAS_CPP14_FLAG TRUE )
         set( HAS_CPPLATEST_FLAG TRUE )
-    else()
-        set( OPTIONS    ${OPTIONS} -W3 )
     endif()
     if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.11 )
         set( HAS_CPP17_FLAG TRUE )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,12 +61,15 @@ if( MSVC )
 
     set( HAS_STD_FLAGS TRUE )
 
-    set( OPTIONS     -W3 -EHsc )
+    set( OPTIONS     -EHsc -WX )
     set( DEFINITIONS -D_SCL_SECURE_NO_WARNINGS )
 
     if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.00 )
+        set( OPTIONS    ${OPTIONS} -W4 )
         set( HAS_CPP14_FLAG TRUE )
         set( HAS_CPPLATEST_FLAG TRUE )
+    else()
+        set( OPTIONS    ${OPTIONS} -W3 )
     endif()
     if( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.11 )
         set( HAS_CPP17_FLAG TRUE )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set( SOURCES
 
 set( ALTERNATE_CONFIG_SOURCES
     gsl-lite.t.cpp
+    not_null.t.cpp
     # TODO: add more
 )
 # Configure gsl-lite for testing:
@@ -42,14 +43,6 @@ set( GSL_CONFIG
     -Dgsl_TESTING_
     -Dgsl_CONFIG_CONTRACT_VIOLATION_THROWS
     -Dgsl_CONFIG_CONTRACT_CHECKING_AUDIT
-)
-set( GSL_ALTERNATE_CONFIG
-    -Dgsl_TESTING_
-    -Dgsl_CONFIG_CONTRACT_VIOLATION_THROWS
-    -Dgsl_CONFIG_CONTRACT_CHECKING_AUDIT
-    -Dgsl_CONFIG_TRANSPARENT_NOT_NULL=1
-    -Dgsl_CONFIG_ALLOWS_NONSTRICT_SPAN_COMPARISON=0
-    -Dgsl_CONFIG_NOT_NULL_EXPLICIT_CTOR=1
 )
 # Preset available C++ language compiler flags:
 
@@ -162,13 +155,13 @@ endfunction()
 
 # Make target, compile for given standard if specified:
 
-function( make_target target std sources extra_definitions )
+function( make_target target std sources defaults_version )
     message( STATUS "Make target: '${std}'" )
 
     add_executable            ( ${target} ${sources}  )
-    target_link_libraries     ( ${target} PRIVATE ${PACKAGE} )
+    target_link_libraries     ( ${target} PRIVATE ${PACKAGE}-${defaults_version} )
     target_compile_options    ( ${target} PRIVATE ${OPTIONS} )
-    target_compile_definitions( ${target} PRIVATE ${DEFINITIONS} ${extra_definitions} )
+    target_compile_definitions( ${target} PRIVATE ${DEFINITIONS} ${GSL_CONFIG} )
 
     if( std )
         if( MSVC )
@@ -187,38 +180,38 @@ endfunction()
 # Add generic executable, unless -std flags can be specified:
 
 if( NOT HAS_STD_FLAGS )
-    make_target( ${PROGRAM}.t        "" "${SOURCES}" "${GSL_CONFIG}" )
-    make_target( ${PROGRAM}-altcfg.t "" "${ALTERNATE_CONFIG_SOURCES}" "${GSL_ALTERNATE_CONFIG}" )
+    make_target( ${PROGRAM}.t        "" "${SOURCES}" v0 )
+    make_target( ${PROGRAM}-altcfg.t "" "${ALTERNATE_CONFIG_SOURCES}" v1 )
 else()
     # unconditionally add C++98 variant as MSVC has no option for it:
     if( HAS_CPP98_FLAG )
-        make_target( ${PROGRAM}-cpp98.t        98 "${SOURCES}" "${GSL_CONFIG}" )
-        make_target( ${PROGRAM}-altcfg-cpp98.t 98 "${ALTERNATE_CONFIG_SOURCES}" "${GSL_ALTERNATE_CONFIG}" )
+        make_target( ${PROGRAM}-cpp98.t        98 "${SOURCES}" v0 )
+        make_target( ${PROGRAM}-altcfg-cpp98.t 98 "${ALTERNATE_CONFIG_SOURCES}" v1 )
     else()
-        make_target( ${PROGRAM}-cpp98.t        "" "${SOURCES}" "${GSL_CONFIG}" )
-        make_target( ${PROGRAM}-altcfg-cpp98.t "" "${ALTERNATE_CONFIG_SOURCES}" "${GSL_ALTERNATE_CONFIG}" )
+        make_target( ${PROGRAM}-cpp98.t        "" "${SOURCES}" v0 )
+        make_target( ${PROGRAM}-altcfg-cpp98.t "" "${ALTERNATE_CONFIG_SOURCES}" v1 )
     endif()
 
     if( HAS_CPP11_FLAG )
-        make_target( ${PROGRAM}-cpp11.t        11 "${SOURCES}" "${GSL_CONFIG}" )
-        make_target( ${PROGRAM}-altcfg-cpp11.t 11 "${ALTERNATE_CONFIG_SOURCES}" "${GSL_ALTERNATE_CONFIG}" )
+        make_target( ${PROGRAM}-cpp11.t        11 "${SOURCES}" v0 )
+        make_target( ${PROGRAM}-altcfg-cpp11.t 11 "${ALTERNATE_CONFIG_SOURCES}" v1 )
     endif()
 
     if( HAS_CPP14_FLAG )
-        make_target( ${PROGRAM}-cpp14.t        14 "${SOURCES}" "${GSL_CONFIG}" )
-        make_target( ${PROGRAM}-altcfg-cpp14.t 14 "${ALTERNATE_CONFIG_SOURCES}" "${GSL_ALTERNATE_CONFIG}" )
+        make_target( ${PROGRAM}-cpp14.t        14 "${SOURCES}" v0 )
+        make_target( ${PROGRAM}-altcfg-cpp14.t 14 "${ALTERNATE_CONFIG_SOURCES}" v1 )
 endif()
 
     if( HAS_CPP17_FLAG )
-        make_target( ${PROGRAM}-cpp17.t        17 "${SOURCES}" "${GSL_CONFIG}" )
+        make_target( ${PROGRAM}-cpp17.t        17 "${SOURCES}" v0 )
         enable_msvs_guideline_checker( ${PROGRAM}-cpp17.t )
-        make_target( ${PROGRAM}-altcfg-cpp17.t        17 "${ALTERNATE_CONFIG_SOURCES}" "${GSL_ALTERNATE_CONFIG}" )
+        make_target( ${PROGRAM}-altcfg-cpp17.t        17 "${ALTERNATE_CONFIG_SOURCES}" v1 )
         enable_msvs_guideline_checker( ${PROGRAM}-altcfg-cpp17.t )
     endif()
 
     if( HAS_CPPLATEST_FLAG )
-        make_target( ${PROGRAM}-cpplatest.t        latest "${SOURCES}" "${GSL_CONFIG}" )
-        make_target( ${PROGRAM}-altcfg-cpplatest.t latest "${ALTERNATE_CONFIG_SOURCES}" "${GSL_ALTERNATE_CONFIG}" )
+        make_target( ${PROGRAM}-cpplatest.t        latest "${SOURCES}" v0 )
+        make_target( ${PROGRAM}-altcfg-cpplatest.t latest "${ALTERNATE_CONFIG_SOURCES}" v1 )
     endif()
 endif()
 


### PR DESCRIPTION
* Add CMake targets `gsl::gsl-lite-v0` and `gsl::gsl-lite-v1` which set versioned defaults.

* Add configuration option `gsl_CONFIG_INDEX_TYPE` which can be configured independently of `gsl_CONFIG_SPAN_INDEX_TYPE`, partly addressing #169.