### PR TITLE
Some fixes to versioned defaults and  `gsl_CONFIG_TRANSPARENT_NOT_NULL` tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
 
 project(
     gsl_lite
-    VERSION 0.35.1
+    VERSION 0.35.2
 #   DESCRIPTION "A single-file header-only version of ISO C++ Guideline Support Library (GSL) for C++98, C++11 and later"
 #   HOMEPAGE_URL "https://github.com/martinmoene/gsl-lite"
     LANGUAGES CXX )
@@ -110,7 +110,7 @@ target_include_directories(
 target_compile_definitions(
     ${package_name}-v1
     INTERFACE
-        gsl_lite_DEFAULTS_VERSION=1)
+        gsl_CONFIG_DEFAULTS_VERSION=1)
 target_sources(
     ${package_name}-v1
     INTERFACE

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ For the [conan package manager](https://www.conan.io/), follow these steps:
 2. Add a reference to *gsl-lite* to the *requires* section of your project's `conanfile.txt` file:
 
         [requires]
-        gsl-lite/0.35.1@nonstd-lite/stable
+        gsl-lite/0.35.2@nonstd-lite/stable
 
 3. Run conan's install command:
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, CMake
 
 class GslLiteConan(ConanFile):
-    version = "0.35.1"
+    version = "0.35.2"
     name = "gsl-lite"
     description = "A single-file header-only version of ISO C++ Guidelines Support Library (GSL) for C++98, C++11 and later"
     license = "MIT License. https://opensource.org/licenses/MIT"

--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -32,7 +32,7 @@
 
 #define  gsl_lite_MAJOR  0
 #define  gsl_lite_MINOR  35
-#define  gsl_lite_PATCH  1
+#define  gsl_lite_PATCH  2
 
 #define  gsl_lite_VERSION  gsl_STRINGIFY(gsl_lite_MAJOR) "." gsl_STRINGIFY(gsl_lite_MINOR) "." gsl_STRINGIFY(gsl_lite_PATCH)
 

--- a/test/not_null.t.cpp
+++ b/test/not_null.t.cpp
@@ -279,7 +279,7 @@ CASE( "not_null<>: Allows to construct from a non-null underlying pointer (raw p
 
 CASE( "not_null<>: Returns underlying pointer with get() (raw pointer)" )
 {
-#if !gsl_CONFIG( NOT_NULL_TRANSPARENT_GET )
+#if !gsl_CONFIG( TRANSPARENT_NOT_NULL )
     int i = 12;
     not_null< int* > p( &i );
 
@@ -479,7 +479,7 @@ CASE( "not_null<>: Returns underlying pointer or raw pointer with get() (shared_
     shared_ptr< int > pi = make_shared< int >(12);
     not_null< shared_ptr< int > > p( pi );
 
-#if gsl_CONFIG( NOT_NULL_TRANSPARENT_GET )
+#if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     int* pg = p.get();
     EXPECT( pg == pi.get() );
 #else
@@ -707,12 +707,12 @@ CASE( "not_null<>: Allows to construct from a non-null raw pointer with explicit
 
 CASE( "not_null<>: Returns underlying pointer or raw pointer with get() (unique_ptr)" )
 {
-#if gsl_CONFIG( NOT_NULL_TRANSPARENT_GET ) || gsl_CONFIG( NOT_NULL_GET_BY_CONST_REF )
+#if gsl_CONFIG( TRANSPARENT_NOT_NULL ) || gsl_CONFIG( NOT_NULL_GET_BY_CONST_REF )
     unique_ptr< int > pi = make_unique< int >(12);
     int* raw(pi.get());
     not_null< unique_ptr< int > > p( std::move(pi) );
 
-# if gsl_CONFIG( NOT_NULL_TRANSPARENT_GET )
+# if gsl_CONFIG( TRANSPARENT_NOT_NULL )
     int* pg = p.get();
     EXPECT( pg == raw );
 # else // gsl_CONFIG( NOT_NULL_GET_BY_CONST_REF )

--- a/test/not_null.t.cpp
+++ b/test/not_null.t.cpp
@@ -178,7 +178,7 @@ CASE( "not_null<>: Copyability and assignability are correctly reported by type 
 
     // Permit construction and assignment from subclass pointer.
     static_assert(  std::is_constructible< not_null< std::unique_ptr< MyBase > >, std::unique_ptr< MyDerived > >::value, "static assertion failed" );
-# if gsl_CONFIG( NOT_NULL_EXPLICIT_CTOR )
+# if gsl_CONFIG( NOT_NULL_EXPLICIT_CTOR ) && ( !defined( __apple_build_version__ ) || __apple_build_version__ >= 9000037 )
     static_assert( !std::is_assignable<    not_null< std::unique_ptr< MyBase > >, std::unique_ptr< MyDerived > >::value, "static assertion failed" );
 # endif
 


### PR DESCRIPTION
- Fix versioned defaults in CMake
- Fix `gsl_CONFIG_TRANSPARENT_NOT_NULL` detection in tests