### PR TITLE
Add `gsl_HAVE_EXCEPTIONS` feature-test macro

### DIFF
--- a/include/gsl/gsl-lite.hpp
+++ b/include/gsl/gsl-lite.hpp
@@ -358,7 +358,7 @@
 
 #define gsl_HAVE_CONTAINER_DATA_METHOD  gsl_CPP11_140_CPP0X_90
 #define gsl_HAVE_STD_DATA               gsl_CPP17_000
-#define gsl_HAVE_STD_SSIZE              ( gsl_COMPILER_GNUC_VERSION >= 1000 || gsl_COMPILER_CLANG_VERSION >= 900 )
+#define gsl_HAVE_STD_SSIZE              ( gsl_COMPILER_GNUC_VERSION >= 1000 )
 
 #define gsl_HAVE_SIZED_TYPES            gsl_CPP11_140
 


### PR DESCRIPTION
Use `gsl_HAVE_EXCEPTIONS` to disable any `throw` statements if no
exceptions are available, and to raise a compile-time error if
`gsl_CONFIG_CONTRACT_VIOLATION_THROWS` is defined without exceptions
available.

Fixes #216.