### PR TITLE
Check for gsl:: target in Config.cmake

### DIFF
--- a/cmake/gsl-lite-config.cmake.in
+++ b/cmake/gsl-lite-config.cmake.in
@@ -2,6 +2,6 @@
 
 # Only include targets once:
 
-if( NOT TARGET @package_name@::@package_name@ )
+if( NOT TARGET @package_nspace@::@package_name@ )
     include( "${CMAKE_CURRENT_LIST_DIR}/@package_target@.cmake" )
 endif()


### PR DESCRIPTION
Currently this file will be generated into a target `gsl-lite::gsl-lite` which doesn't exist.

I don't think this check is even needed, AFAIU the `targets.cmake` file will do this check also.