### PR TITLE
add fix for nvhpc compiler

### DIFF
--- a/include/gsl-lite/gsl-lite.hpp
+++ b/include/gsl-lite/gsl-lite.hpp
@@ -2790,13 +2790,13 @@ struct not_null_elem
 {
     typedef typename element_type_helper<T>::type element_type;
 
-#if gsl_CONFIG( TRANSPARENT_NOT_NULL )
+#if gsl_CONFIG( TRANSPARENT_NOT_NULL ) && ! gsl_COMPILER_NVHPC_VERSION
     gsl_NODISCARD gsl_api gsl_constexpr14 element_type *
     get() const
     {
         return not_null_accessor<T>::get_checked( static_cast< Derived const & >( *this ) ).get();
     }
-#endif // gsl_CONFIG( TRANSPARENT_NOT_NULL )
+#endif // gsl_CONFIG( TRANSPARENT_NOT_NULL ) && ! gsl_COMPILER_NVHPC_VERSION
 };
 template< class Derived, class T >
 struct not_null_elem< Derived, T, false >
@@ -3141,18 +3141,18 @@ gsl_is_delete_access:
     not_null & operator=( int ) gsl_is_delete;
 #endif
 
-#if gsl_STDLIB_CPP11_140 && ( gsl_CPP14_OR_GREATER || ! gsl_COMPILER_NVCC_VERSION )
+#if gsl_STDLIB_CPP11_140 && ( gsl_CPP14_OR_GREATER || ( ! gsl_COMPILER_NVCC_VERSION && ! gsl_COMPILER_NVHPC_VERSION ) )
     template< class... Ts >
     gsl_api gsl_constexpr14 auto
     operator()( Ts&&... args ) const
-# if ! gsl_COMPILER_NVCC_VERSION
-        // NVCC thinks that Substitution Failure Is An Error here
+# if ! gsl_COMPILER_NVCC_VERSION && ! gsl_COMPILER_NVHPC_VERSION
+        // NVCC and NVHPC think that Substitution Failure Is An Error here
         -> decltype( data_.ptr_( std::forward<Ts>( args )... ) )
-# endif // ! gsl_COMPILER_NVCC_VERSION
+# endif // ! gsl_COMPILER_NVCC_VERSION && ! gsl_COMPILER_NVHPC_VERSION
     {
         return accessor::get_checked( *this )( std::forward<Ts>( args )... );
     }
-#endif // gsl_STDLIB_CPP11_140 && ( gsl_CPP14_OR_GREATER || ! gsl_COMPILER_NVCC_VERSION )
+#endif // gsl_STDLIB_CPP11_140 && ( gsl_CPP14_OR_GREATER || ( ! gsl_COMPILER_NVCC_VERSION && ! gsl_COMPILER_NVHPC_VERSION ) )
 
     // unwanted operators...pointers only point to single objects!
     not_null & operator++() gsl_is_delete;


### PR DESCRIPTION
## Description
This PR fixes build failures with the NVHPC compiler. Like NVCC, it does not handle some advanced C++ template features.

## Changes

1. Disabled a not_null accessor method for the NVHPC compiler to prevent a compilation error.
2. Applied an existing workaround for NVCC not handling SFINAE to also cover the NVHPC compiler, which has the same issue.